### PR TITLE
Use TinyMCE for annotation editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The name taḥqīq (tah-KEEK) comes from the Arabic for text edition.
 
 - Node.JS v16.x
 - NPM v8.x
+- TinyMCE v5 (can be from CDN)
 - Annotorious
 - An annotation store supported by an Annotorious plugin
 
@@ -29,6 +30,8 @@ const storagePlugin = StoragePlugin(); // An Annotorious plugin for storing anno
 const annotationContainer = document.getElementById("annotation"); // An empty HTML element that the editor will be placed into.
 new TranscriptionEditor(client, storagePlugin, annotationContainer);
 ```
+
+An instance of TinyMCE v5 must also be available on the `window` object. This can simply be a script tag that pulls TinyMCE from a CDN.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The name taḥqīq (tah-KEEK) comes from the Arabic for text edition.
 
 - Node.JS v16.x
 - NPM v8.x
-- TinyMCE v5 (can be from CDN)
+- TinyMCE v5 (recommended to use script tag pointing to Tiny CDN)
 - Annotorious
 - An annotation store supported by an Annotorious plugin
 
@@ -31,7 +31,11 @@ const annotationContainer = document.getElementById("annotation"); // An empty H
 new TranscriptionEditor(client, storagePlugin, annotationContainer);
 ```
 
-An instance of TinyMCE v5 must also be available on the `window` object. This can simply be a script tag that pulls TinyMCE from a CDN.
+An instance of TinyMCE v5 must also be available on the `window` object. It is recommended to simply use a script tag that pulls TinyMCE from the official CDN. For example:
+
+```html
+<script src="https://cdn.tiny.cloud/1/API_KEY/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+```
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "annotorious-tahqiq",
             "version": "1.0.0",
             "license": "Apache-2.0",
+            "dependencies": {
+                "@tinymce/tinymce-webcomponent": "^2.0.0"
+            },
             "devDependencies": {
                 "@tsconfig/node16": "^1.0.2",
                 "@types/jest": "^27.5.0",
@@ -1172,6 +1175,11 @@
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
             }
+        },
+        "node_modules/@tinymce/tinymce-webcomponent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.0.tgz",
+            "integrity": "sha512-w2vjtEthv6uKZbnTRNb81Chwfa5q+Ct6jBDWErhDq7rSTCoaPBZIYOauLZx29eCZ0ix0qFKfa4wtYMKxS+d44Q=="
         },
         "node_modules/@tootallnate/once": {
             "version": "2.0.0",
@@ -8385,6 +8393,11 @@
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
             }
+        },
+        "@tinymce/tinymce-webcomponent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.0.tgz",
+            "integrity": "sha512-w2vjtEthv6uKZbnTRNb81Chwfa5q+Ct6jBDWErhDq7rSTCoaPBZIYOauLZx29eCZ0ix0qFKfa4wtYMKxS+d44Q=="
         },
         "@tootallnate/once": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "volta": {
         "node": "16.15.0",
         "npm": "8.8.0"
+    },
+    "dependencies": {
+        "@tinymce/tinymce-webcomponent": "^2.0.0"
     }
 }

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -85,6 +85,24 @@ class AnnotationBlock extends HTMLDivElement {
     }
 
     /**
+     * Utility function to encode HTML into entities for use in TinyMCE.
+     *
+     * @param {string} content The HTML content to be encoded.
+     * @returns {string} Content with encoded HTML entities.
+     */
+    encodeHTML(content: string): string {
+        return content.replace(/[&<>'"]/g, 
+            (tag: string) => ({
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                "'": "&#39;",
+                '"': "&quot;",
+            }[tag] || tag));
+    }
+
+
+    /**
      * Makes an existing annotation block editable by adding TinyMCE
      * and adding Save, Cancel, and Delete buttons.
      */
@@ -100,7 +118,7 @@ class AnnotationBlock extends HTMLDivElement {
         window.tinyConfig.init_instance_callback = this.setEditorId.bind(this);
         const editor = document.createElement("tinymce-editor");
         editor.setAttribute("config", "tinyConfig");
-        editor.innerHTML = this.textInput.innerHTML;
+        editor.innerHTML = this.encodeHTML(this.textInput.innerHTML);
         this.textInput.innerHTML = "";
         this.textInput.append(editor);
         this.textInput.focus();

--- a/src/types/@tinymce/tinymce-webcomponent.d.ts
+++ b/src/types/@tinymce/tinymce-webcomponent.d.ts
@@ -1,0 +1,2 @@
+// required for tinymce webcomponent to not throw TypeScript errors
+declare module "@tinymce/tinymce-webcomponent";

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -48,3 +48,15 @@ describe("Element initialization", () => {
         expect(makeEditableSpy).toBeCalledTimes(1);
     });
 });
+
+describe("HTML encoding utility", () => {
+    it("Should encode special characters as HTML entities", () => {
+        const block = new AnnotationBlock(props);
+        expect(block.encodeHTML("<b>Test</b>")).toBe("&lt;b&gt;Test&lt;/b&gt;");
+        expect(block.encodeHTML("'1 & 2'")).toBe("&#39;1 &amp; 2&#39;");
+    });
+    it("Should not modify strings without TinyMCE special characters", () => {
+        const block = new AnnotationBlock(props);
+        expect(block.encodeHTML("!@#?$test")).toBe("!@#?$test");
+    });
+});


### PR DESCRIPTION
## In this PR

- Per Princeton-CDH/geniza#916:
  - Use TinyMCE WebComponent (replacing `contenteditable` div) for adding/editing annotations
  - Add TinyMCE config, set as a property on `window` per [TinyMCE documentation](https://www.tiny.cloud/docs/integrations/webcomponent/#settingadditionalconfigurationoptions)
  - Add new `editorId` property to `AnnotationBlock` so that we can use the `getContent` function (which needs `window.tinymce.get(editorId)`) to read and store TinyMCE content

## Dev notes

- Relies on https://github.com/Princeton-CDH/geniza/pull/945 (as it needs `window.tinymce` to be available)