### PR TITLE
Allow editing of annotation labels

### DIFF
--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -10,7 +10,7 @@ import { SaveButton } from "./SaveButton";
 class AnnotationBlock extends HTMLDivElement {
     annotation: Annotation;
 
-    textInput: HTMLDivElement;
+    bodyElement: HTMLDivElement;
 
     editorId?: string;
 
@@ -68,19 +68,19 @@ class AnnotationBlock extends HTMLDivElement {
         this.append(this.labelElement);
 
         // Create and append body element (div with text in read-only, TinyMCE in edit mode)
-        this.textInput = document.createElement("div");
+        this.bodyElement = document.createElement("div");
         if (
             Array.isArray(this.annotation.body) &&
             this.annotation.body.length > 0
         ) {
-            this.textInput.innerHTML = this.annotation.body[0].value;
+            this.bodyElement.innerHTML = this.annotation.body[0].value;
         }
-        this.append(this.textInput);
+        this.append(this.bodyElement);
 
         // Set click event listeners
         if (this.annotation.id) {
             this.dataset.annotationId = this.annotation.id;
-            this.textInput.addEventListener("click", () => {
+            this.bodyElement.addEventListener("click", () => {
                 this.onClick(this);
                 // selection event not fired in this case, so make editable
                 this.makeEditable();
@@ -133,11 +133,11 @@ class AnnotationBlock extends HTMLDivElement {
         window.tinyConfig.init_instance_callback = this.setEditorId.bind(this);
         const editor = document.createElement("tinymce-editor");
         editor.setAttribute("config", "tinyConfig");
-        editor.innerHTML = this.encodeHTML(this.textInput.innerHTML);
-        this.textInput.setAttribute("class", "annotation-editor");
-        this.textInput.innerHTML = "";
-        this.textInput.append(editor);
-        this.textInput.focus();
+        editor.innerHTML = this.encodeHTML(this.bodyElement.innerHTML);
+        this.bodyElement.setAttribute("class", "annotation-editor");
+        this.bodyElement.innerHTML = "";
+        this.bodyElement.append(editor);
+        this.bodyElement.focus();
 
         // add save and cancel buttons
         this.append(new SaveButton(this));
@@ -158,11 +158,11 @@ class AnnotationBlock extends HTMLDivElement {
     makeReadOnly(updateAnnotation?: boolean): void {
         this.setAttribute("class", "annotation-display-container");
         this.labelElement.setAttribute("contenteditable", "false");
-        this.textInput.setAttribute("class", "");
+        this.bodyElement.setAttribute("class", "");
         // restore the original content
         if (updateAnnotation) {
             if (Array.isArray(this.annotation.body) && this.annotation.body.length > 0) {
-                this.textInput.innerHTML = this.annotation.body[0].value;
+                this.bodyElement.innerHTML = this.annotation.body[0].value;
             }
             if (this.annotation.label) {
                 this.labelElement.innerHTML = this.annotation.label;
@@ -173,7 +173,7 @@ class AnnotationBlock extends HTMLDivElement {
         } else {
             // otherwise, set the content to TinyMCE editor's content
             const editorContent = window.tinymce.get(this.editorId).getContent();
-            this.textInput.innerHTML = editorContent;
+            this.bodyElement.innerHTML = editorContent;
         }
         // remove buttons (or should we just hide them?)
         this.querySelectorAll("button").forEach((el) => el.remove());

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -62,19 +62,16 @@ class AnnotationBlock extends HTMLDivElement {
 
         // Create and append label element (div with text, contenteditable in edit mode)
         this.labelElement = document.createElement("h3");
-        if (this.annotation.label) {
-            this.labelElement.innerHTML = this.annotation.label;
-        }
-        this.append(this.labelElement);
-
         // Create and append body element (div with text in read-only, TinyMCE in edit mode)
         this.bodyElement = document.createElement("div");
         if (
             Array.isArray(this.annotation.body) &&
             this.annotation.body.length > 0
         ) {
+            this.labelElement.innerHTML = this.annotation.body[0].label || "";
             this.bodyElement.innerHTML = this.annotation.body[0].value;
         }
+        this.append(this.labelElement);
         this.append(this.bodyElement);
 
         // Set click event listeners
@@ -163,9 +160,7 @@ class AnnotationBlock extends HTMLDivElement {
         if (updateAnnotation) {
             if (Array.isArray(this.annotation.body) && this.annotation.body.length > 0) {
                 this.bodyElement.innerHTML = this.annotation.body[0].value;
-            }
-            if (this.annotation.label) {
-                this.labelElement.innerHTML = this.annotation.label;
+                this.labelElement.innerHTML = this.annotation.body[0].label || "";
             }
             // add the annotation again to update the image selection region,
             // in case the user has modified it and wants to cancel

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,8 +193,8 @@ class TranscriptionEditor {
     }
 
     /**
-     * Saves the passed annotation block's associated annotation using its
-     * editor content, and makes the annotation block read only.
+     * Saves the passed annotation block's associated annotation using its editor
+     * content (and label if present), and makes the annotation block read only.
      *
      * @param {HTMLElement} annotationBlock Annotation block associated with the annotation to save.
      */
@@ -203,6 +203,9 @@ class TranscriptionEditor {
         const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
         // add the content to the annotation
         annotation.motivation = "supplementing";
+        if (annotationBlock.labelElement.textContent) {
+            annotation.label = annotationBlock.labelElement.textContent;
+        }
         if (Array.isArray(annotation.body) && annotation.body.length == 0) {
             annotation.body.push({
                 type: "TextualBody",

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,21 +203,22 @@ class TranscriptionEditor {
         const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
         // add the content to the annotation
         annotation.motivation = "supplementing";
-        if (annotationBlock.labelElement.textContent) {
-            annotation.label = annotationBlock.labelElement.textContent;
-        }
         if (Array.isArray(annotation.body) && annotation.body.length == 0) {
             annotation.body.push({
                 type: "TextualBody",
                 purpose: "transcribing",
                 value: editorContent || "",
                 format: "text/html",
+                label: annotationBlock.labelElement.textContent || undefined,
                 // TODO: transcription motivation, language, etc.
             });
         } else if (Array.isArray(annotation.body)) {
             // assume text content is first body element
             annotation.body[0].value =
                 editorContent || "";
+            if (annotationBlock.labelElement.textContent) {
+                annotation.body[0].label = annotationBlock.labelElement.textContent;
+            }
         }
         // update with annotorious, then save to storage backend
         await this.anno.updateSelected(annotation);

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -12,7 +12,6 @@ interface Annotation {
     motivation: string;
     target: Target;
     type: string;
-    label?: string;
 }
 
 /**

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -12,6 +12,7 @@ interface Annotation {
     motivation: string;
     target: Target;
     type: string;
+    label?: string;
 }
 
 /**

--- a/src/types/Body.ts
+++ b/src/types/Body.ts
@@ -9,6 +9,7 @@ interface Body {
     purpose?: string;
     format?: string;
     language?: string;
+    label?: string;
 }
 
 export { Body };

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -28,11 +28,11 @@ describe("Element initialization", () => {
         const block = new AnnotationBlock(props);
         expect(block.className).toBe("annotation-display-container");
     });
-    it("Should create and append text input", () => {
+    it("Should create and append body and label elements", () => {
         const createElementSpy = jest.spyOn(document, "createElement");
         const block = new AnnotationBlock(props);
-        expect(createElementSpy).toBeCalledTimes(1);
-        expect(block.childNodes.length).toBe(1);
+        expect(createElementSpy).toBeCalledTimes(2);
+        expect(block.childNodes.length).toBe(2);
     });
     it("Should set editable when editable prop is true", () => {
         const makeEditableSpy = jest.spyOn(


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/915:
  - Allow editing of annotation labels, displayed in UI as `h3` elements with `contenteditable` property (turned off in read-only mode), and saved as the `label` property on the annotation resource

## Dev notes

- Relies on https://github.com/Princeton-CDH/annotorious-sas-storage/pull/7 to persist labels
