### PR TITLE
Update cached annotation on target change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { CancelButton } from "./elements/CancelButton";
 import { DeleteButton } from "./elements/DeleteButton";
 import { SaveButton } from "./elements/SaveButton";
 import { Annotation } from "./types/Annotation";
+import { Target } from "./types/Target";
 import { Editor } from "@tinymce/tinymce-webcomponent";
 
 declare global {
@@ -27,6 +28,8 @@ class TranscriptionEditor {
 
     storage;
 
+    currentAnnotationBlock: AnnotationBlock | null;
+
     // TODO: Add typedefs for the Annotorious client (anno) and storage plugin
 
     /**
@@ -44,6 +47,7 @@ class TranscriptionEditor {
         // disable the default annotorious editor (headless mode)
         this.anno.disableEditor = true;
         this.annotationContainer = annotationContainer;
+        this.currentAnnotationBlock = null;
 
         // define custom elements
         if (!customElements.get("save-button"))
@@ -73,6 +77,10 @@ class TranscriptionEditor {
             "selectAnnotation",
             this.handleSelectAnnotation.bind(this),
         );
+        this.anno.on(
+            "changeSelectionTarget",
+            this.handleChangeSelectionTarget.bind(this),
+        );
 
         // Prepare tinyMCE editor custom element and config
         if (!customElements.get("tinymce-editor")) {
@@ -101,6 +109,7 @@ class TranscriptionEditor {
                 menubar: {}, // disable menu bar
             };
         }
+
     }
 
     /**
@@ -162,6 +171,23 @@ class TranscriptionEditor {
             // make sure no other editor is active
             this.makeAllReadOnlyExcept(annotationBlock);
             annotationBlock.makeEditable();
+            // set current annotation block
+            this.currentAnnotationBlock = <AnnotationBlock>annotationBlock;
+        }
+    }
+
+    /**
+     *
+     * Update the cached annotation on the currently selected annotation block
+     * when the target changes.
+     *
+     * @param {Target} target updated target from an Annotorious annotation.
+     */
+    handleChangeSelectionTarget(target: Target) {
+        // if there is an annotation block currently active,
+        // update the cached annotation with the changed target
+        if (this.currentAnnotationBlock != null) {
+            this.currentAnnotationBlock.annotation.target = target;
         }
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -45,7 +45,7 @@ describe("Plugin instantiation", () => {
         new TranscriptionEditor(clientMock, storageMock, container);
         expect(addEventListenerSpy).toBeCalledTimes(1);
         // should also attach even listeners to client events
-        expect(clientMock.on).toBeCalledTimes(2);
+        expect(clientMock.on).toBeCalledTimes(3);
     });
     it("Should define custom elements on initialization", () => {
         new TranscriptionEditor(clientMock, storageMock, container);


### PR DESCRIPTION
This update solves a problem we've known about for a while — if you select an annotation, change the zone on the image and save, it works fine, but if you then edit the text and save again, you lose the change to the annotation target. I figured out a solution while I was working on the other changes but thought it would be better to update & review separately.

My solution is to add a handler for the `changeSelectionTarget` Annotorious event and update the cached annotation on the currently active `AnnotationBlock`. I wasn't sure the most efficient way to identify the currently active block; I added a variable for it on the class, and it's being set properly, but I don't know if we need to clear it out (and if so, when / where we could trigger that). I don't think it should be possible to change the selection target without having an annotation selected, so maybe this is fine.

