### PR TITLE
Allow clicking on empty annotations to edit

### DIFF
--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -79,19 +79,19 @@ class AnnotationBlock extends HTMLDivElement {
         this.append(this.labelElement);
         this.append(this.bodyElement);
 
-        // Set click event listeners
         if (this.annotation.id) {
             this.dataset.annotationId = this.annotation.id;
-            this.bodyElement.addEventListener("click", () => {
+        }
+
+        // Set click event listener
+        this.addEventListener("click", () => {
+            // if you click on this block, and it is in read-only mode, make editable
+            if (!this.classList.contains("tahqiq-block-editor")) {
                 this.onClick(this);
                 // selection event not fired in this case, so make editable
                 this.makeEditable();
-            });
-            this.labelElement.addEventListener("click", () => {
-                this.onClick(this);
-                this.makeEditable();
-            });
-        }
+            }
+        });
 
         // Set editable if needed
         if (props.editable) {

--- a/src/elements/CancelButton.ts
+++ b/src/elements/CancelButton.ts
@@ -26,9 +26,12 @@ class CancelButton extends HTMLButtonElement {
 
     /**
      * On click, cancel edit/create annotation.
+     *
+     * @param {Event} evt Click event
      */
-    handleClick() {
+    handleClick(evt: Event) {
         // cancel the edit
+        evt.stopPropagation(); // ensure parent onClick event isn't called
         // clear the selection from the image
         this.annotationBlock.onCancel();
         if (this.annotationBlock.annotation.id) {

--- a/src/elements/DeleteButton.ts
+++ b/src/elements/DeleteButton.ts
@@ -26,8 +26,11 @@ class DeleteButton extends HTMLButtonElement {
 
     /**
      * Delete the annotation on click.
+     *
+     * @param {Event} evt Click event
      */
-    handleClick() {
+    handleClick(evt: Event) {
+        evt.stopPropagation(); // ensure parent onClick event isn't called
         this.annotationBlock.onDelete(this.annotationBlock);
     }
 }

--- a/src/elements/SaveButton.ts
+++ b/src/elements/SaveButton.ts
@@ -28,8 +28,11 @@ class SaveButton extends HTMLButtonElement {
 
     /**
      * Calls the save function from the annotation block.
+     *
+     * @param {Event} evt Click event
      */
-    async handleClick(): Promise<void> {
+    async handleClick(evt: Event): Promise<void> {
+        evt.stopPropagation(); // ensure parent onClick event isn't called
         await this.annotationBlock.onSave(this.annotationBlock);
     }
 }

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -47,6 +47,11 @@ describe("Element initialization", () => {
         });
         expect(makeEditableSpy).toBeCalledTimes(1);
     });
+    it("Should add click event listener", () => {
+        const addEventListenerSpy = jest.spyOn(AnnotationBlock.prototype, "addEventListener");
+        new AnnotationBlock(props);
+        expect(addEventListenerSpy).toBeCalledTimes(1);
+    });
 });
 
 describe("HTML encoding utility", () => {

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -54,6 +54,28 @@ describe("Element initialization", () => {
     });
 });
 
+describe("Click event", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("Should call onClick and makeEditable if in read-only mode", () => {
+        const block = new AnnotationBlock(props);
+        const evt = new MouseEvent("click");
+        block.dispatchEvent(evt);
+        expect(block.onClick).toHaveBeenCalledTimes(1);
+        expect(block.makeEditable).toHaveBeenCalledTimes(1);
+    });
+    it("Should do nothing if in editor mode", () => {
+        const block = new AnnotationBlock(props);
+        // set to editor mode
+        block.classList.add("tahqiq-block-editor");
+        const evt = new MouseEvent("click");
+        block.dispatchEvent(evt);
+        expect(block.onClick).toHaveBeenCalledTimes(0);
+        expect(block.makeEditable).toHaveBeenCalledTimes(0);
+    });
+});
+
 describe("HTML encoding utility", () => {
     it("Should encode special characters as HTML entities", () => {
         const block = new AnnotationBlock(props);

--- a/tests/elements/CancelButton.test.ts
+++ b/tests/elements/CancelButton.test.ts
@@ -3,6 +3,17 @@ import { CancelButton } from "../../src/elements/CancelButton";
 
 // Mock annotationBlock
 jest.mock("../../src/elements/AnnotationBlock");
+const annoBlock = new (AnnotationBlock as jest.Mock<AnnotationBlock>)();
+annoBlock.onCancel = jest.fn();
+annoBlock.remove = jest.fn();
+annoBlock.makeReadOnly = jest.fn();
+annoBlock.annotation = {
+    "@context": "fake context",
+    body: { value: "text" },
+    motivation: "commenting",
+    target: { source: "fake source" },
+    type: "Annotation",
+};
 
 describe("Element initialization", () => {
     beforeAll(() => {
@@ -12,12 +23,37 @@ describe("Element initialization", () => {
         });
     });
     beforeEach(() => {
-        (AnnotationBlock as jest.Mock<AnnotationBlock>).mockClear();
+        jest.clearAllMocks();
     });
     it("Should set class and text content", () => {
-        const annoBlock = new (AnnotationBlock as jest.Mock<AnnotationBlock>)();
         const cancelButton = new CancelButton(annoBlock);
         expect(cancelButton.classList).toContain("tahqiq-cancel-button");
         expect(cancelButton.textContent).toBe("Cancel");
+    });
+});
+
+describe("Click handler", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("Should stop event propagation up to parent element", () => {
+        const cancelButton = new CancelButton(annoBlock);
+        const evt = new MouseEvent("click");
+        const propagationSpy = jest.spyOn(evt, "stopPropagation");
+        cancelButton.dispatchEvent(evt);
+        expect(propagationSpy).toBeCalledTimes(1);
+    });
+    it("Should call remove if annotation.id is undefined", () => {
+        const cancelButton = new CancelButton(annoBlock);
+        const evt = new MouseEvent("click");
+        cancelButton.dispatchEvent(evt);
+        expect(annoBlock.remove).toBeCalledTimes(1);
+    });
+    it("Should call makeReadOnly if annotation.id is defined", () => {
+        annoBlock.annotation.id = "test";
+        const cancelButton = new CancelButton(annoBlock);
+        const evt = new MouseEvent("click");
+        cancelButton.dispatchEvent(evt);
+        expect(annoBlock.makeReadOnly).toBeCalledWith(true);
     });
 });

--- a/tests/elements/DeleteButton.test.ts
+++ b/tests/elements/DeleteButton.test.ts
@@ -4,6 +4,17 @@ import { DeleteButton } from "../../src/elements/DeleteButton";
 // Mock annotationBlock
 jest.mock("../../src/elements/AnnotationBlock");
 
+// mock an annotation block for this button
+const annoBlock = new (AnnotationBlock as jest.Mock<AnnotationBlock>)();
+annoBlock.onDelete = jest.fn();
+annoBlock.annotation = {
+    "@context": "fake context",
+    body: { value: "text" },
+    motivation: "commenting",
+    target: { source: "fake source" },
+    type: "Annotation",
+};
+
 describe("Element initialization", () => {
     beforeAll(() => {
         // register custom element
@@ -12,12 +23,30 @@ describe("Element initialization", () => {
         });
     });
     beforeEach(() => {
-        (AnnotationBlock as jest.Mock<AnnotationBlock>).mockClear();
+        jest.clearAllMocks();
     });
     it("Should set class and text content", () => {
-        const annoBlock = new (AnnotationBlock as jest.Mock<AnnotationBlock>)();
         const deleteButton = new DeleteButton(annoBlock);
         expect(deleteButton.classList).toContain("tahqiq-delete-button");
         expect(deleteButton.textContent).toBe("Delete");
+    });
+});
+
+describe("Click handler", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("Should stop event propagation up to parent element", () => {
+        const deleteButton = new DeleteButton(annoBlock);
+        const evt = new MouseEvent("click");
+        const propagationSpy = jest.spyOn(evt, "stopPropagation");
+        deleteButton.dispatchEvent(evt);
+        expect(propagationSpy).toBeCalledTimes(1);
+    });
+    it("Should call onDelete", () => {
+        const deleteButton = new DeleteButton(annoBlock);
+        const evt = new MouseEvent("click");
+        deleteButton.dispatchEvent(evt);
+        expect(annoBlock.onDelete).toBeCalledWith(annoBlock);
     });
 });

--- a/tests/elements/SaveButton.test.ts
+++ b/tests/elements/SaveButton.test.ts
@@ -3,6 +3,15 @@ import { SaveButton } from "../../src/elements/SaveButton";
 
 // Mock annotationBlock
 jest.mock("../../src/elements/AnnotationBlock");
+const annoBlock = new (AnnotationBlock as jest.Mock<AnnotationBlock>)();
+annoBlock.onSave = jest.fn();
+annoBlock.annotation = {
+    "@context": "fake context",
+    body: { value: "text" },
+    motivation: "commenting",
+    target: { source: "fake source" },
+    type: "Annotation",
+};
 
 describe("Element initialization", () => {
     beforeAll(() => {
@@ -12,12 +21,30 @@ describe("Element initialization", () => {
         });
     });
     beforeEach(() => {
-        (AnnotationBlock as jest.Mock<AnnotationBlock>).mockClear();
+        jest.clearAllMocks();
     });
     it("Should set class and text content", () => {
-        const annoBlock = new (AnnotationBlock as jest.Mock<AnnotationBlock>)();
         const saveButton = new SaveButton(annoBlock);
         expect(saveButton.classList).toContain("tahqiq-save-button");
         expect(saveButton.textContent).toBe("Save");
+    });
+});
+
+describe("Click handler", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("Should stop event propagation up to parent element", () => {
+        const saveButton = new SaveButton(annoBlock);
+        const evt = new MouseEvent("click");
+        const propagationSpy = jest.spyOn(evt, "stopPropagation");
+        saveButton.dispatchEvent(evt);
+        expect(propagationSpy).toBeCalledTimes(1);
+    });
+    it("Should call onSave", () => {
+        const saveButton = new SaveButton(annoBlock);
+        const evt = new MouseEvent("click");
+        saveButton.dispatchEvent(evt);
+        expect(annoBlock.onSave).toBeCalledWith(annoBlock);
     });
 });


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/916:
  - Set the click event listener to "make editable" on the entire annotation block, instead of just the label and body child elements
  - Ensure that click event is not called during editing / when clicking one of the save/delete/cancel buttons