### PR TITLE
Support saving with and retrieving by source URI

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -68,6 +68,10 @@ class AnnotationServerStorage {
         annotation.target.source = this.adjustTargetSource(
             annotation.target.source,
         );
+        // save source URI to dc:source attribute on annotation
+        if (this.settings.sourceUri) {
+            annotation["dc:source"] = this.settings.sourceUri;
+        }
 
         // wait for adapter to return saved annotation from storage
         const newAnnotation: Annotation = await this.create(
@@ -184,7 +188,9 @@ class AnnotationServerStorage {
      * @param {string} targetUri URI of the target to search for
      */
     async search(targetUri: string): Promise<void | SavedAnnotation[]> {
-        return fetch(`${this.settings.annotationEndpoint}search/?uri=${targetUri}`, {
+        const { annotationEndpoint, sourceUri } = this.settings;
+        const sourceQuery = sourceUri ? `&source=${sourceUri}` : "";
+        return fetch(`${annotationEndpoint}search/?uri=${targetUri}${sourceQuery}`, {
             headers: {
                 Accept: "application/json",
                 "Content-Type": "application/json",

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -8,6 +8,7 @@ import type { Target } from "./Target";
 interface Annotation {
     "@context": string;
     body: Body | Body[];
+    "dc:source"?: string;
     id?: string;
     motivation: string;
     target: Target;

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -6,6 +6,7 @@ interface Settings {
     target: string;
     manifest: string;
     csrf_token: string;
+    sourceUri?: string;
 }
 
 export { Settings };

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -30,6 +30,7 @@ const settings = {
     manifest: "fakeManifest",
     target: "fakeCanvas",
     csrf_token: "fakeToken",
+    sourceUri: "https://fakesource.uri",
 };
 
 // a fake annotation
@@ -113,13 +114,20 @@ describe("Event handlers", () => {
             JSON.stringify({
                 ...fakeAnnotation,
                 id: "assignedId",
+                "dc:source": "https://fakesource.uri",
             }),
             {
                 status: 200,
                 statusText: "ok",
             },
         );
+        const createSpy = jest.spyOn(AnnotationServerStorage.prototype, "create");
         await clientMock.emit("createAnnotation", fakeAnnotation);
+        // should include dc:source in annotation passed to create method
+        expect(createSpy).toHaveBeenCalledWith({
+            ...fakeAnnotation,
+            "dc:source": "https://fakesource.uri",
+        });
         // should get new id from server
         const newAnnotation = {
             ...fakeAnnotation,
@@ -163,15 +171,14 @@ describe("Event handlers", () => {
                 statusText: "ok",
             },
         );
-
-        const newAnnotation = {
+        const newAnnotation2 = {
             ...fakeAnnotation,
             id: "assignedId",
             target: { source: "fakesource" },
         };
         clientMock.emit("updateAnnotation", annotation, previous);
         // should call addAnnotation on client
-        expect(clientMock.addAnnotation).toHaveBeenCalledWith(newAnnotation);
+        expect(clientMock.addAnnotation).toHaveBeenCalledWith(newAnnotation2);
     });
 
     it("should respond to emitted deleteAnnotation event with handler", async () => {


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/913:
  - Include source URI in search queries when present
  - Allow `dc:source` attribute on Annotations, and save it when present