### PR TITLE
Reorder annotation blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,23 @@ An instance of TinyMCE v5 must also be available on the `window` object. It is r
 
 This plugin exposes the following CSS classes that can be used to style its elements:
 
-- `.tahqiq-block-display`: Container `div` containing an annotation label and body
-- `.tahqiq-block-editor`: Container `div` when in edit mode
-- `.tahqiq-label-display`: `h3` elements for block labels
-- `.tahqiq-label-editor`: Editable `h3` elements for block labels
-- `.tahqiq-body-display`: `div` element displaying the content of an annotation body
-- `.tahqiq-body-editor`: `div` element containing the TinyMCE editor for editing an annotation body
-- `.tahqiq-button`: All buttons (save, delete, cancel)
-- `.tahqiq-save-button`: Save button
-- `.tahqiq-delete-button`: Delete button
-- `.tahqiq-cancel-button`: Cancel button
+- Annotation blocks
+  - `.tahqiq-block-display`: Container `div` containing an annotation label and body
+  - `.tahqiq-block-editor`: Container `div` when in edit mode
+  - `.tahqiq-label-display`: `h3` elements for block labels
+  - `.tahqiq-label-editor`: Editable `h3` elements for block labels
+  - `.tahqiq-body-display`: `div` element displaying the content of an annotation body
+  - `.tahqiq-body-editor`: `div` element containing the TinyMCE editor for editing an annotation body
+- Buttons
+  - `.tahqiq-button`: All buttons (save, delete, cancel)
+  - `.tahqiq-save-button`: Save button
+  - `.tahqiq-delete-button`: Delete button
+  - `.tahqiq-cancel-button`: Cancel button
+- Drag and drop
+  - `.tahqiq-drag-targetable`: Annotation container receives this class when the user begins dragging another annotation (i.e. this annotation container is "targetable")
+  - `.tahqiq-drag-target`: Annotation container receives this class when the user hovers a dragged annotation over it (i.e. this annotation container is "targeted")
+  - `.tahqiq-drop-zone`: When running multiple instances of Tahqiq on the same page, this `div` will appear on an instance that has no annotations when the user begins dragging an annotation from another instance 
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This plugin exposes the following CSS classes that can be used to style its elem
   - `.tahqiq-drag-targetable`: Annotation container receives this class when the user begins dragging another annotation (i.e. this annotation container is "targetable")
   - `.tahqiq-drag-target`: Annotation container receives this class when the user hovers a dragged annotation over it (i.e. this annotation container is "targeted")
   - `.tahqiq-drop-zone`: When running multiple instances of Tahqiq on the same page, this `div` will appear on an instance that has no annotations when the user begins dragging an annotation from another instance 
-
+  - `.tahqiq-loading`: To compensate for network request timing, this class is added to all annotation containers after a drag and drop is completed, and removed when the network requests are finished
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@tinymce/tinymce-webcomponent": "^2.0.0"
+                "@tinymce/tinymce-webcomponent": "^2.0.0",
+                "@ungap/custom-elements": "^1.1.0"
             },
             "devDependencies": {
                 "@tsconfig/node16": "^1.0.2",
@@ -1595,6 +1596,11 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@ungap/custom-elements": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.1.0.tgz",
+            "integrity": "sha512-jPOtG6F8Wfmu3C+SF6lAglg/GsMGeiQCelikCrARXodcCVbH51GjG1Ga2GfM+WsxmRfnenLaUBLrkdxduHSGOA=="
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -9218,6 +9224,11 @@
                 "@typescript-eslint/types": "5.22.0",
                 "eslint-visitor-keys": "^3.0.0"
             }
+        },
+        "@ungap/custom-elements": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.1.0.tgz",
+            "integrity": "sha512-jPOtG6F8Wfmu3C+SF6lAglg/GsMGeiQCelikCrARXodcCVbH51GjG1Ga2GfM+WsxmRfnenLaUBLrkdxduHSGOA=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "npm": "8.8.0"
     },
     "dependencies": {
-        "@tinymce/tinymce-webcomponent": "^2.0.0"
+        "@tinymce/tinymce-webcomponent": "^2.0.0",
+        "@ungap/custom-elements": "^1.1.0"
     }
 }

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -24,6 +24,8 @@ class AnnotationBlock extends HTMLDivElement {
 
     onDelete: (annotationBlock: AnnotationBlock) => void;
 
+    onDragOver: (annotationBlock: AnnotationBlock | null) => void;
+
     onSave: (annotationBlock: AnnotationBlock) => Promise<void>;
 
     updateAnnotorious: (annotation: Annotation) => void;
@@ -36,6 +38,7 @@ class AnnotationBlock extends HTMLDivElement {
      * @param {boolean} props.editable True if this annotation block should be editable,
      * otherwise false.
      * @param {Function} props.onClick Click handler function.
+     * @param {Function} props.onDragOver Dragover handler function.
      * @param {Function} props.onSave Save annotation handler function.
      * @param {Function} props.onDelete Delete annotation handler function.
      * @param {Function} props.onCancel Cancel annotation handler function.
@@ -49,6 +52,7 @@ class AnnotationBlock extends HTMLDivElement {
         onClick: (annotationBlock: AnnotationBlock) => void;
         onDelete: (annotationBlock: AnnotationBlock) => void;
         onSave: (annotationBlock: AnnotationBlock) => Promise<void>;
+        onDragOver: (annotationBlock: AnnotationBlock | null) => void;
         updateAnnotorious: (annotation: Annotation) => void;
     }) {
         super();
@@ -56,6 +60,7 @@ class AnnotationBlock extends HTMLDivElement {
         this.onCancel = props.onCancel;
         this.onClick = props.onClick;
         this.onDelete = props.onDelete;
+        this.onDragOver = props.onDragOver;
         this.onSave = props.onSave;
         this.updateAnnotorious = props.updateAnnotorious;
 
@@ -93,6 +98,13 @@ class AnnotationBlock extends HTMLDivElement {
             }
         });
 
+        // Set drag event listeners
+        this.draggable = true;
+        this.addEventListener("dragstart", this.startDrag.bind(this));
+        this.addEventListener("dragover", () => this.onDragOver(this));
+        this.addEventListener("dragend", () => this.onDragOver(null));
+        // this.addEventListener("drop", dropBlock);
+
         // Set editable if needed
         if (props.editable) {
             this.makeEditable();
@@ -127,6 +139,7 @@ class AnnotationBlock extends HTMLDivElement {
         }
 
         this.setAttribute("class", "tahqiq-block-editor");
+        this.draggable = false;
 
         // make label editable
         this.labelElement.setAttribute("contenteditable", "true");
@@ -160,6 +173,7 @@ class AnnotationBlock extends HTMLDivElement {
      */
     makeReadOnly(updateAnnotation?: boolean): void {
         this.setAttribute("class", "tahqiq-block-display");
+        this.draggable = true;
         this.labelElement.setAttribute("contenteditable", "false");
         this.labelElement.setAttribute("class", "tahqiq-label-display");
         this.bodyElement.setAttribute("class", "tahqiq-body-display");
@@ -198,6 +212,29 @@ class AnnotationBlock extends HTMLDivElement {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setEditorId(editor:any) {
         this.editorId = editor.id;
+    }
+
+    /**
+     * On drag start, set the drag data to the dragged item's ID
+     *
+     * @param {DragEvent} evt The "dragstart" DragEvent
+     */
+    startDrag(evt: DragEvent) {
+        const target = evt.target as AnnotationBlock;
+        evt.dataTransfer?.setData("text", target?.dataset?.annotationId || "");
+    }
+
+    /**
+     * When a block is dragged over, give it "tahqiq-drag-target" style; else, remove that style.
+     *
+     * @param {boolean} draggedOver Boolean indicating whether this block is being dragged over.
+     */
+    setDraggedOver(draggedOver: boolean): void {
+        if (draggedOver) {
+            this.classList.add("tahqiq-drag-target");
+        } else {
+            this.classList.remove("tahqiq-drag-target");
+        }
     }
 }
 

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -9,7 +9,7 @@ import "../styles/AnnotationBlock.scss";
  * HTML div element associated with an annotation, which can be made editable to udpate
  * or delete its associated annotation.
  */
-class AnnotationBlock extends HTMLDivElement {
+class AnnotationBlock extends HTMLElement {
     annotation: Annotation;
 
     bodyElement: HTMLDivElement;
@@ -107,7 +107,7 @@ class AnnotationBlock extends HTMLDivElement {
         this.draggable = true;
         this.addEventListener("dragstart", this.startDrag.bind(this));
         this.addEventListener("dragover", (evt) => {
-            evt.preventDefault();
+            evt.preventDefault(); // required to allow drop
             this.onDragOver(this);
         });
         this.addEventListener("dragend", () => this.onDragOver(null));

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -244,6 +244,16 @@ class AnnotationBlock extends HTMLDivElement {
             this.classList.remove("tahqiq-drag-target");
         }
     }
+
+    /**
+     * Set whether or not this annotation block can be drag and dropped.
+     * Should not be draggable during editing or loading.
+     * 
+     * @param {boolean} draggable Boolean indicating if this block is draggable.
+     */
+    setDraggable(draggable: boolean): void {
+        this.draggable = draggable;
+    }
 }
 
 export { AnnotationBlock };

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -26,6 +26,8 @@ class AnnotationBlock extends HTMLDivElement {
 
     onDragOver: (annotationBlock: AnnotationBlock | null) => void;
 
+    onReorder: (evt: DragEvent) => void;
+
     onSave: (annotationBlock: AnnotationBlock) => Promise<void>;
 
     updateAnnotorious: (annotation: Annotation) => void;
@@ -37,11 +39,12 @@ class AnnotationBlock extends HTMLDivElement {
      * @param {Annotation} props.annotation Annotation to associate with this annotation block.
      * @param {boolean} props.editable True if this annotation block should be editable,
      * otherwise false.
+     * @param {Function} props.onCancel Cancel annotation handler function.
      * @param {Function} props.onClick Click handler function.
+     * @param {Function} props.onDelete Delete annotation handler function.
      * @param {Function} props.onDragOver Dragover handler function.
      * @param {Function} props.onSave Save annotation handler function.
-     * @param {Function} props.onDelete Delete annotation handler function.
-     * @param {Function} props.onCancel Cancel annotation handler function.
+     * @param {Function} props.onReorder Drop event handler function.
      * @param {Function} props.updateAnnotorious Function that updates this annotation in the
      * Annotorious display.
      */
@@ -51,8 +54,9 @@ class AnnotationBlock extends HTMLDivElement {
         onCancel: () => void;
         onClick: (annotationBlock: AnnotationBlock) => void;
         onDelete: (annotationBlock: AnnotationBlock) => void;
-        onSave: (annotationBlock: AnnotationBlock) => Promise<void>;
         onDragOver: (annotationBlock: AnnotationBlock | null) => void;
+        onReorder: (evt: DragEvent) => void;
+        onSave: (annotationBlock: AnnotationBlock) => Promise<void>;
         updateAnnotorious: (annotation: Annotation) => void;
     }) {
         super();
@@ -61,6 +65,7 @@ class AnnotationBlock extends HTMLDivElement {
         this.onClick = props.onClick;
         this.onDelete = props.onDelete;
         this.onDragOver = props.onDragOver;
+        this.onReorder = props.onReorder;
         this.onSave = props.onSave;
         this.updateAnnotorious = props.updateAnnotorious;
 
@@ -101,9 +106,12 @@ class AnnotationBlock extends HTMLDivElement {
         // Set drag event listeners
         this.draggable = true;
         this.addEventListener("dragstart", this.startDrag.bind(this));
-        this.addEventListener("dragover", () => this.onDragOver(this));
+        this.addEventListener("dragover", (evt) => {
+            evt.preventDefault();
+            this.onDragOver(this);
+        });
         this.addEventListener("dragend", () => this.onDragOver(null));
-        // this.addEventListener("drop", dropBlock);
+        this.addEventListener("drop", this.onReorder);
 
         // Set editable if needed
         if (props.editable) {

--- a/src/elements/CancelButton.ts
+++ b/src/elements/CancelButton.ts
@@ -1,4 +1,5 @@
 import { AnnotationBlock } from "./AnnotationBlock";
+import "@ungap/custom-elements";
 
 /**
  * A button that cancels editing or creating an annotation on click.

--- a/src/elements/DeleteButton.ts
+++ b/src/elements/DeleteButton.ts
@@ -1,4 +1,5 @@
 import { AnnotationBlock } from "./AnnotationBlock";
+import "@ungap/custom-elements";
 
 /**
  * A button that deletes an annotation from both Annotorious display and the annotation store.

--- a/src/elements/SaveButton.ts
+++ b/src/elements/SaveButton.ts
@@ -1,4 +1,5 @@
 import { AnnotationBlock } from "./AnnotationBlock";
+import "@ungap/custom-elements";
 
 /**
  * A button to save a selected annotation to the store.

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,6 +333,9 @@ class TranscriptionEditor {
      * When an annotation block is dropped, set its position and check its neighbors' positions
      * for changes. If any positions changed, save changed annotations.
      *
+     * TODO: Test once DragEvent is implemented in jsdom
+     * https://github.com/jsdom/jsdom/blob/28ed5/test/web-platform-tests/to-run.yaml#L648-L654
+     * 
      * @param {DragEvent} evt The "drop" event that triggered this handler
      */
     async handleDropAnnotationBlock(evt: DragEvent) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,6 +368,14 @@ class TranscriptionEditor {
      */
     async handleDropAnnotationBlock(evt: DragEvent) {
         evt.preventDefault();
+        // set loading style to prepare for network requests
+        this.annotationContainer
+            .querySelectorAll("annotation-block")
+            .forEach((block) => {
+                if (block instanceof AnnotationBlock) {
+                    block.classList.add("tahqiq-loading");
+                }
+            });
         const blocks = this.annotationContainer.querySelectorAll("annotation-block");
         const annotations = Array.from(blocks).map((block) => {
             if (block instanceof AnnotationBlock) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,6 +261,8 @@ class TranscriptionEditor {
                 annotation.body[0].label = annotationBlock.labelElement.textContent;
             }
         }
+        console.log("[handleSaveAnnotation] Selection:");
+        console.log(annotation);
         // update with annotorious, then save to storage backend
         await this.anno.updateSelected(annotation);
         this.anno.saveSelected();

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,7 @@ class TranscriptionEditor {
                 extends: "button",
             });
         if (!customElements.get("annotation-block"))
-            customElements.define("annotation-block", AnnotationBlock, {
-                extends: "div",
-            });
+            customElements.define("annotation-block", AnnotationBlock);
 
         // attach event listeners
         document.addEventListener(
@@ -406,7 +404,7 @@ class TranscriptionEditor {
      */
     setAllDraggability(draggable: boolean) {
         this.annotationContainer
-            .querySelectorAll("div")
+            .querySelectorAll("annotation-block")
             .forEach((block) => {
                 if (block instanceof AnnotationBlock) {
                     block.setDraggable(draggable);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Annotation } from "./types/Annotation";
 import { Target } from "./types/Target";
 import { Editor } from "@tinymce/tinymce-webcomponent";
 import AnnotationServerStorage from "./storage";
+import "@ungap/custom-elements";
 
 import "./styles/index.scss";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ class TranscriptionEditor {
         this.currentAnnotationBlock = null;
 
         // define custom elements
+
+        // FIXME: "extends" setting does not work on Safari, nor does inheritance
+        // of element types other than HTMLElement. Buttons will not display.
         if (!customElements.get("save-button"))
             customElements.define("save-button", SaveButton, {
                 extends: "button",

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -72,6 +72,8 @@ class AnnotationServerStorage {
         if (this.settings.sourceUri) {
             annotation["dc:source"] = this.settings.sourceUri;
         }
+        console.log("[handleCreateAnnotation] After Annotorious processing:");
+        console.log(annotation);
 
         // wait for adapter to return saved annotation from storage
         const newAnnotation: Annotation = await this.create(

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -55,11 +55,23 @@ class AnnotationServerStorage {
      */
     async loadAnnotations() {
         const annotations: void | SavedAnnotation[] = await this.search(this.settings.target);
-        this.anno.setAnnotations(annotations);
+
+        // sort by position attribute if present
+        // null position should go to the end; it means dragged from another canvas
+        if (annotations)
+            annotations.sort((a: Annotation, b: Annotation) => {
+                if (a["schema:position"] === null) return 1;
+                if (b["schema:position"] === null) return -1;
+                if (a["schema:position"] && b["schema:position"])
+                    return a["schema:position"] - b["schema:position"];
+                return 0;
+            });
+        await this.anno.setAnnotations(annotations);
         if (annotations instanceof Array) {
             this.annotationCount = annotations.length;
         }
         setTimeout(() => document.dispatchEvent(AnnoLoadEvent), 100);
+        return annotations;
     }
 
     /**

--- a/src/styles/AnnotationBlock.scss
+++ b/src/styles/AnnotationBlock.scss
@@ -1,3 +1,4 @@
+// Read-only mode annotation block styling
 .tahqiq-block-display {
     border: 1px solid rgba(128, 128, 128, 0.5);
     margin: 0.5rem;
@@ -6,9 +7,15 @@
         border: 1px solid rgba(128, 128, 128, 1);
         cursor: pointer;
     }
+    // Dragged over styling
+    &.tahqiq-drag-target {
+        border: 2px dashed rgba(128, 128, 128, 0.5);
+    }
 }
 
+// Edit mode annotation block styling
 .tahqiq-block-editor {
+    // Editable label with placeholder
     .tahqiq-label-editor {
         background-color: white;
         color: black;

--- a/src/styles/AnnotationBlock.scss
+++ b/src/styles/AnnotationBlock.scss
@@ -1,5 +1,6 @@
 // Read-only mode annotation block styling
 .tahqiq-block-display {
+    display: block;
     border: 1px solid rgba(128, 128, 128, 0.5);
     margin: 0.5rem;
     padding: 0.5rem;
@@ -15,6 +16,7 @@
 
 // Edit mode annotation block styling
 .tahqiq-block-editor {
+    display: block;
     // Editable label with placeholder
     .tahqiq-label-editor {
         background-color: white;

--- a/src/styles/AnnotationBlock.scss
+++ b/src/styles/AnnotationBlock.scss
@@ -12,6 +12,9 @@
     &.tahqiq-drag-target {
         border: 2px dashed rgba(128, 128, 128, 0.5);
     }
+    * {
+        pointer-events: none;
+    }
 }
 
 // Edit mode annotation block styling

--- a/src/styles/AnnotationBlock.scss
+++ b/src/styles/AnnotationBlock.scss
@@ -4,14 +4,26 @@
     border: 1px solid rgba(128, 128, 128, 0.5);
     margin: 0.5rem;
     padding: 0.5rem;
+    opacity: 1;
+    transition: opacity 200ms;
+    pointer-events: all;
     &:hover {
         border: 1px solid rgba(128, 128, 128, 1);
         cursor: pointer;
     }
+    // Drag and drop
     // Dragged over styling
     &.tahqiq-drag-target {
         border: 2px dashed rgba(128, 128, 128, 0.5);
     }
+    // Waiting for network requests after a drop
+    &.tahqiq-loading {
+        opacity: 0.3;
+        pointer-events: none;
+        cursor: default;
+    }
+    // Required to prevent unwanted dragenter and dragleave events from bubbling
+    // via child elements
     * {
         pointer-events: none;
     }
@@ -20,6 +32,7 @@
 // Edit mode annotation block styling
 .tahqiq-block-editor {
     display: block;
+    opacity: 1;
     // Editable label with placeholder
     .tahqiq-label-editor {
         background-color: white;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,12 @@
+.tahqiq-drop-zone {
+    width: 100%;
+    height: 100px;
+    display: block;
+    border: none;
+    &.tahqiq-drag-targetable {
+        border: 1px solid rgba(128, 128, 128, 0.5);
+    }
+    &.tahqiq-drag-target {
+        border: 2px dashed rgba(128, 128, 128, 0.5);
+    }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,6 +1,6 @@
 .tahqiq-drop-zone {
     width: 100%;
-    height: 100px;
+    height: 100%;
     display: block;
     border: none;
     &.tahqiq-drag-targetable {

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -11,7 +11,7 @@ interface Annotation {
     "dc:source"?: string;
     id?: string;
     motivation: string;
-    "schema:position"?: number;
+    "schema:position"?: number | null;
     target: Target;
     type: string;
 }

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -11,6 +11,7 @@ interface Annotation {
     "dc:source"?: string;
     id?: string;
     motivation: string;
+    "schema:position"?: number;
     target: Target;
     type: string;
 }

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -14,6 +14,7 @@ const props = {
     onClick: jest.fn(),
     onDelete: jest.fn(),
     onDragOver: jest.fn(),
+    onReorder: jest.fn(),
     onSave: jest.fn(),
     updateAnnotorious: jest.fn(),
 };

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -87,3 +87,16 @@ describe("HTML encoding utility", () => {
         expect(block.encodeHTML("!@#?$test")).toBe("!@#?$test");
     });
 });
+
+describe("Drag event", () => {
+    // TODO: Test "dragstart" and dataTransfer once DragEvent is implemented in jsdom
+    // https://github.com/jsdom/jsdom/blob/28ed5/test/web-platform-tests/to-run.yaml#L648-L654
+
+    it("Adds or removes drag target class when block dragged over", () => {
+        const block = new AnnotationBlock(props);
+        block.setDraggedOver(true);
+        expect(block.classList.contains("tahqiq-drag-target")).toBe(true);
+        block.setDraggedOver(false);
+        expect(block.classList.contains("tahqiq-drag-target")).toBe(false);
+    });
+});

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -13,7 +13,7 @@ const props = {
     onCancel: jest.fn(),
     onClick: jest.fn(),
     onDelete: jest.fn(),
-    onDragOver: jest.fn(),
+    onDrag: jest.fn(),
     onReorder: jest.fn(),
     onSave: jest.fn(),
     updateAnnotorious: jest.fn(),
@@ -50,7 +50,7 @@ describe("Element initialization", () => {
     it("Should add click, drag, drop event listeners", () => {
         const addEventListenerSpy = jest.spyOn(AnnotationBlock.prototype, "addEventListener");
         new AnnotationBlock(props);
-        expect(addEventListenerSpy).toBeCalledTimes(5);
+        expect(addEventListenerSpy).toBeCalledTimes(7);
     });
 });
 

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -13,6 +13,7 @@ const props = {
     onCancel: jest.fn(),
     onClick: jest.fn(),
     onDelete: jest.fn(),
+    onDragOver: jest.fn(),
     onSave: jest.fn(),
     updateAnnotorious: jest.fn(),
 };

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -49,10 +49,10 @@ describe("Element initialization", () => {
         });
         expect(makeEditableSpy).toBeCalledTimes(1);
     });
-    it("Should add click event listener", () => {
+    it("Should add click, drag, drop event listeners", () => {
         const addEventListenerSpy = jest.spyOn(AnnotationBlock.prototype, "addEventListener");
         new AnnotationBlock(props);
-        expect(addEventListenerSpy).toBeCalledTimes(1);
+        expect(addEventListenerSpy).toBeCalledTimes(5);
     });
 });
 

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -22,9 +22,7 @@ const props = {
 describe("Element initialization", () => {
     beforeAll(() => {
         // register custom element
-        customElements.define("annotation-block", AnnotationBlock, {
-            extends: "div",
-        });
+        customElements.define("annotation-block", AnnotationBlock);
     });
     it("Should set display class", () => {
         const block = new AnnotationBlock(props);

--- a/tests/elements/CancelButton.test.ts
+++ b/tests/elements/CancelButton.test.ts
@@ -1,5 +1,6 @@
 import { AnnotationBlock } from "../../src/elements/AnnotationBlock";
 import { CancelButton } from "../../src/elements/CancelButton";
+jest.mock("@ungap/custom-elements");
 
 // Mock annotationBlock
 jest.mock("../../src/elements/AnnotationBlock");

--- a/tests/elements/DeleteButton.test.ts
+++ b/tests/elements/DeleteButton.test.ts
@@ -1,5 +1,6 @@
 import { AnnotationBlock } from "../../src/elements/AnnotationBlock";
 import { DeleteButton } from "../../src/elements/DeleteButton";
+jest.mock("@ungap/custom-elements");
 
 // Mock annotationBlock
 jest.mock("../../src/elements/AnnotationBlock");

--- a/tests/elements/SaveButton.test.ts
+++ b/tests/elements/SaveButton.test.ts
@@ -1,5 +1,6 @@
 import { AnnotationBlock } from "../../src/elements/AnnotationBlock";
 import { SaveButton } from "../../src/elements/SaveButton";
+jest.mock("@ungap/custom-elements");
 
 // Mock annotationBlock
 jest.mock("../../src/elements/AnnotationBlock");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -111,9 +111,6 @@ describe("Drag over annotation", () => {
     });
 });
 
-// TODO: Test handleDropAnnotationBlock once DragEvent is implemented in jsdom
-// https://github.com/jsdom/jsdom/blob/28ed5/test/web-platform-tests/to-run.yaml#L648-L654
-
 const fakeAnnotationList = [
     { ...fakeAnnotation, id: "first", "schema:position": 2 },
     { ...fakeAnnotation, id: "second" },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -46,9 +46,9 @@ const clientMock = {
 };
 // Mock the storage plugin
 const storageMock = {
-    adapter: {
-        delete: jest.fn(),
-    },
+    delete: jest.fn(),
+    loadAnnotations: jest.fn(),
+    update: jest.fn(),
 };
 const container = document.createElement("annotation-block");
 
@@ -121,3 +121,6 @@ describe("Drag over annotation", () => {
         });
     });
 });
+
+// TODO: Test handleDropAnnotationBlock once DragEvent is implemented in jsdom
+// https://github.com/jsdom/jsdom/blob/28ed5/test/web-platform-tests/to-run.yaml#L648-L654

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -144,3 +144,25 @@ describe("Update annotations sequence", () => {
         expect(storageMock.loadAnnotations).toBeCalledTimes(1);
     });
 });
+
+describe("Reload all positions", () => {
+    beforeEach(() => {
+        storageMock.loadAnnotations.mockClear();
+    });
+
+    it("Should retrieve annotations from storage, then run updateSequence", async () => {
+        const editor = new TranscriptionEditor(clientMock, storageMock, container);
+        const loadAnnotationsSpy = jest.spyOn(storageMock, "loadAnnotations");
+        const updateSequenceSpy = jest.spyOn(editor, "updateSequence");
+        const resolvedAnnos = [
+            { ...fakeAnnotation, id: "first", "schema:position": 4 },
+            { ...fakeAnnotation, id: "second", "schema:position": 2 },
+        ];
+        storageMock.loadAnnotations.mockResolvedValueOnce(resolvedAnnos);
+        await editor.handleReloadAllPositions();
+        // called once by handleReloadAllPositions, and once by updateSequence
+        expect(loadAnnotationsSpy).toBeCalledTimes(2);
+        // should reorder the returned annotations
+        expect(updateSequenceSpy).toBeCalledWith(resolvedAnnos);
+    });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -20,14 +20,14 @@ const clientMock = {
     addAnnotation: jest.fn(),
     removeAnnotation: jest.fn(),
     getAnnotations: jest.fn().mockReturnValue([
-        {
-            ...fakeAnnotation,
-            "schema:position": 3,
-        },
         fakeAnnotation,
         {
             ...fakeAnnotation,
             "schema:position": 2,
+        },
+        {
+            ...fakeAnnotation,
+            "schema:position": 3,
         },
     ]),
     cancelSelected: jest.fn(),
@@ -56,7 +56,7 @@ describe("Plugin instantiation", () => {
     it("Should attach event listeners on initialization", () => {
         const addEventListenerSpy = jest.spyOn(document, "addEventListener");
         new TranscriptionEditor(clientMock, storageMock, container);
-        expect(addEventListenerSpy).toBeCalledTimes(1);
+        expect(addEventListenerSpy).toBeCalledTimes(2);
         // should also attach even listeners to client events
         expect(clientMock.on).toBeCalledTimes(3);
     });
@@ -66,19 +66,6 @@ describe("Plugin instantiation", () => {
         expect(customElements.get("save-button")).toBeDefined();
         expect(customElements.get("delete-button")).toBeDefined();
         expect(customElements.get("cancel-button")).toBeDefined();
-    });
-});
-
-describe("Load annotations", () => {
-    it("Should sort annotations by schema:position attribute", () => {
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
-        editor.handleAnnotationsLoaded();
-        const blocks = editor.annotationContainer.querySelectorAll("annotation-block");
-        blocks.forEach((block, index) => {
-            if (block instanceof AnnotationBlock) {
-                expect(block.annotation["schema:position"]).toEqual(index + 1);
-            }
-        });
     });
 });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,5 @@
-import TranscriptionEditor from "../src";
+import { TranscriptionEditor } from "../src";
+
 
 // Mock the Annotorious client
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -28,7 +29,7 @@ const storageMock = {
         delete: jest.fn(),
     },
 };
-const container = document.createElement("div");
+const container = document.createElement("annotation-block");
 
 // mock custom elements definition; required to prevent naming conflicts
 const customElementsSpy = jest.spyOn(customElements, "define");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -85,32 +85,6 @@ describe("Set annotations draggable", () => {
     });
 });
 
-describe("Drag over annotation", () => {
-    it("Should add drag target class to passed block and remove from all others", () => {
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
-        editor.handleAnnotationsLoaded();
-        const blocks = editor.annotationContainer.querySelectorAll("annotation-block");
-        const draggedOver = blocks[0];
-        const other = blocks[1];
-        if (draggedOver && draggedOver instanceof AnnotationBlock) {
-            editor.handleDragOverAnnotationBlock(draggedOver);
-            expect(draggedOver.classList.contains("tahqiq-drag-target")).toBe(true);
-            if (other) {
-                expect(other.classList.contains("tahqiq-drag-target")).toBe(false);
-            }
-        }
-    });
-    it("Should remove drag target class from all blocks if null passed", () => {
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
-        editor.handleAnnotationsLoaded();
-        editor.handleDragOverAnnotationBlock(null);
-        const blocks = editor.annotationContainer.querySelectorAll("annotation-block");
-        blocks.forEach((block) => {
-            expect(block.classList.contains("tahqiq-drag-target")).toBe(false);
-        });
-    });
-});
-
 const fakeAnnotationList = [
     { ...fakeAnnotation, id: "first", "schema:position": 2 },
     { ...fakeAnnotation, id: "second" },

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -215,3 +215,42 @@ describe("Event handlers", () => {
         expect(storage.annotationCount).toEqual(0);
     });
 });
+
+describe("Load annotations", () => {
+    beforeEach(() => {
+        // Reset mocks before each test
+        clientMock.on.mockClear();
+        clientMock.setAnnotations.mockClear();
+        fetchMock.resetMocks();
+    });
+    it("Should sort annotations by schema:position attribute, with nulls at the end", async () => {
+        fetchMock.mockResponse(
+            JSON.stringify([
+                {
+                    ...fakeAnnotation,
+                    "schema:position": null,
+                },
+                fakeAnnotation,
+                {
+                    ...fakeAnnotation,
+                    "schema:position": 1,
+                },
+                {
+                    ...fakeAnnotation,
+                    "schema:position": 3,
+                },
+            ]),
+            {
+                status: 200,
+                statusText: "ok",
+            },
+        );
+        const storage = new AnnotationServerStorage(clientMock, settings);
+        const annotations = await storage.loadAnnotations();
+        if (annotations && annotations.length) {
+            expect(annotations.length).toEqual(4);
+            expect(annotations[0]["schema:position"]).toEqual(1);
+            expect(annotations[3]["schema:position"]).toEqual(null);
+        }
+    });
+});

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -39,6 +39,7 @@ const fakeAnnotation = {
     "@context": "fakeContext",
     body: {},
     motivation: "commenting",
+    "schema:position": 2,
     target: { source: "fakesource" },
     type: "Annotation",
 };

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -90,6 +90,13 @@ describe("Storage instantiation", () => {
 
         expect(clientMock.on).toHaveBeenCalledTimes(3);
     });
+
+    it("Should set annotationCount to 0", () => {
+        // initialize the storage
+        const storage = new AnnotationServerStorage(clientMock, settings);
+
+        expect(storage.annotationCount).toEqual(0);
+    });
 });
 
 describe("Event handlers", () => {
@@ -109,7 +116,7 @@ describe("Event handlers", () => {
                 statusText: "ok",
             },
         );
-        new AnnotationServerStorage(clientMock, settings);
+        const storage = new AnnotationServerStorage(clientMock, settings);
 
         fetchMock.mockResponseOnce(
             JSON.stringify({
@@ -137,6 +144,9 @@ describe("Event handlers", () => {
         };
         // should call addAnnotation on client
         expect(clientMock.addAnnotation).toHaveBeenCalledWith(newAnnotation);
+
+        // should increment annotationCount
+        expect(storage.annotationCount).toEqual(1);
     });
 
     it("should respond to emitted updateAnnotation event with handler", async () => {
@@ -191,7 +201,7 @@ describe("Event handlers", () => {
                 statusText: "ok",
             },
         );
-        new AnnotationServerStorage(clientMock, settings);
+        const storage = new AnnotationServerStorage(clientMock, settings);
 
         fetchMock.mockResponseOnce(JSON.stringify({}), {
             status: 200,
@@ -201,5 +211,7 @@ describe("Event handlers", () => {
         clientMock.emit("deleteAnnotation", fakeAnnotation);
         // should call adapter.delete
         // expect(fetchMock).toHaveBeenCalledWith(fakeAnnotation.id);
+        // should decrement annotationCount
+        expect(storage.annotationCount).toEqual(0);
     });
 });


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1021:
  - Allow dragging and dropping annotations within a page to reorder them, setting the `schema:position` attribute for all affected annotations
  - Set new annotations' `schema:position` attribute to 1 if no other annotations exist on the page, otherwise set it to the last one's position + 1
- Per https://github.com/Princeton-CDH/geniza/issues/1022:
  - Allow dragging annotations to other canvases, changing target source ID
  - Append them to the end of the list in terms of `schema:position`
  - Add a drop zone to canvases without any annotations so that annotations can be dragged onto them\ 
- Fix broken behavior in Safari: refactor annotation blocks to not extend `HTMLDivElement`, and use a polyfill for the buttons

## Questions

- Should I write tests for the rest of `index.ts`? I think we had held off because the UI was still in flux, but it seems rather solidified now. (A decent number of misses in this PR are inside existing functions that we haven't tested yet)

---

### dev notes

- [x] note: Button extensions do not work on safari
  - [x] todo: see if [polyfilling](https://github.com/ungap/custom-elements) works
- [x] note: Cannot test DragEvent
- [x] todo: allow dragging between canvases 
- [x] todo: test `updateSequence`
- [x] todo: test `handleReloadAllPositions`
- [x] todo: allow annotations to be dragged onto a canvas without any annotations