### PR TITLE
Add Tiny API key to constructor/tinyMCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The name taḥqīq (tah-KEEK) comes from the Arabic for text edition.
 
 - Node.JS v16.x
 - NPM v8.x
-- TinyMCE v5 (recommended to use script tag pointing to Tiny CDN)
 - Annotorious
 - An annotation store supported by an Annotorious plugin
 
@@ -30,13 +29,8 @@ Then, to use alongside Annotorious and a storage plugin:
 const client = Annotorious(annotoriousSettings);
 const storagePlugin = StoragePlugin(); // An Annotorious plugin for storing annotations
 const annotationContainer = document.getElementById("annotation"); // An empty HTML element that the editor will be placed into.
-new TranscriptionEditor(client, storagePlugin, annotationContainer);
-```
-
-An instance of TinyMCE v5 must also be available on the `window` object. It is recommended to simply use a script tag that pulls TinyMCE from the official CDN. For example:
-
-```html
-<script src="https://cdn.tiny.cloud/1/API_KEY/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+const tinyApiKey = "1234567890"; // Your TinyMCE editor API key.
+new TranscriptionEditor(client, storagePlugin, annotationContainer, tinyApiKey);
 ```
 
 ### Styling

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -166,6 +166,7 @@ class AnnotationBlock extends HTMLElement {
         window.tinyConfig.init_instance_callback = this.setEditorId.bind(this);
         const editor = document.createElement("tinymce-editor");
         editor.setAttribute("config", "tinyConfig");
+        editor.setAttribute("api-key", window.tinyApiKey);
         editor.innerHTML = this.encodeHTML(this.bodyElement.innerHTML);
         this.bodyElement.setAttribute("class", "tahqiq-body-editor");
         this.bodyElement.innerHTML = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ declare global {
         tinyConfig: any;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         tinymce: any;
+        tinyApiKey: string;
     }
 }
 
@@ -46,9 +47,10 @@ class TranscriptionEditor {
      * @param {any} storage Storage plugin to save Annotorious annotations.
      * @param {HTMLElement} annotationContainer Existing HTML element that the editor will be
      * placed into.
+     * @param {string} tinyApiKey API key for the TinyMCE rich text editor.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(anno: any, storage: any, annotationContainer: HTMLElement) {
+    constructor(anno: any, storage: any, annotationContainer: HTMLElement, tinyApiKey: string) {
         this.anno = anno;
         this.storage = storage;
         // disable the default annotorious editor (headless mode)
@@ -120,6 +122,9 @@ class TranscriptionEditor {
                 li { padding-right: 1em; } ins { color: gray; }",
                 menubar: {}, // disable menu bar
             };
+        }
+        if (!window.tinyApiKey) {
+            window.tinyApiKey = tinyApiKey;
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ class TranscriptionEditor {
                 content_style:
                     "::marker {direction: ltr; margin-left: 1em; }\
                 li { padding-right: 1em; } ins { color: gray; }",
-                menubar: {}, // disable menu bar
+                menubar: false, // disable menu bar
             };
         }
         if (!window.tinyApiKey) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,13 +57,13 @@ const container = document.createElement("annotation-block");
 describe("Plugin instantiation", () => {
     it("Should attach event listeners on initialization", () => {
         const addEventListenerSpy = jest.spyOn(document, "addEventListener");
-        new TranscriptionEditor(clientMock, storageMock, container);
+        new TranscriptionEditor(clientMock, storageMock, container, "fakeTinyMceKey");
         expect(addEventListenerSpy).toBeCalledTimes(2);
         // should also attach even listeners to client events
         expect(clientMock.on).toBeCalledTimes(3);
     });
     it("Should define custom elements on initialization", () => {
-        new TranscriptionEditor(clientMock, storageMock, container);
+        new TranscriptionEditor(clientMock, storageMock, container, "fakeTinyMceKey");
         expect(customElements.get("annotation-block")).toBeDefined();
         expect(customElements.get("save-button")).toBeDefined();
         expect(customElements.get("delete-button")).toBeDefined();
@@ -73,7 +73,9 @@ describe("Plugin instantiation", () => {
 
 describe("Set annotations draggable", () => {
     it("Should change the draggable property on all annotation blocks", () => {
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
         editor.handleAnnotationsLoaded();
         editor.setAllDraggability(false);
         const blocks = editor.annotationContainer.querySelectorAll("annotation-block");
@@ -95,7 +97,9 @@ const fakeAnnotationList = [
 describe("Update annotations sequence", () => {
     it("Should set schema:position on all passed annotations to their list indices", async () => {
         const updateSpy = jest.spyOn(storageMock, "update");
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
         await editor.updateSequence(fakeAnnotationList);
         // should only be called 3 times, as only 3/4 need to be updated
         expect(updateSpy).toBeCalledTimes(3);
@@ -110,7 +114,9 @@ describe("Update annotations sequence", () => {
         });
     });
     it("Should set all draggability to false and reload all annotations", async () => {
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
         const draggabilitySpy = jest.spyOn(editor, "setAllDraggability");
         storageMock.loadAnnotations.mockClear();
         await editor.updateSequence(fakeAnnotationList);
@@ -125,7 +131,9 @@ describe("Reload all positions", () => {
     });
 
     it("Should retrieve annotations from storage, then run updateSequence", async () => {
-        const editor = new TranscriptionEditor(clientMock, storageMock, container);
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
         const loadAnnotationsSpy = jest.spyOn(storageMock, "loadAnnotations");
         const updateSequenceSpy = jest.spyOn(editor, "updateSequence");
         const resolvedAnnos = [


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1065:
  - Add Tiny API key to tahqiq constructor
  - Pass Tiny API key to web component
- Update "disable menubar" config for current version of Tiny

## Questions

- Should the api key be an optional param, or good to leave as required?