### PR TITLE
Reload annotations from storage after saving

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -55,17 +55,6 @@ class AnnotationServerStorage {
      */
     async loadAnnotations() {
         const annotations: void | SavedAnnotation[] = await this.search(this.settings.target);
-
-        // sort by position attribute if present
-        // null position should go to the end; it means dragged from another canvas
-        if (annotations)
-            annotations.sort((a: Annotation, b: Annotation) => {
-                if (a["schema:position"] === null) return 1;
-                if (b["schema:position"] === null) return -1;
-                if (a["schema:position"] && b["schema:position"])
-                    return a["schema:position"] - b["schema:position"];
-                return 0;
-            });
         await this.anno.setAnnotations(annotations);
         if (annotations instanceof Array) {
             this.annotationCount = annotations.length;
@@ -216,7 +205,7 @@ class AnnotationServerStorage {
 
     /**
      *
-     * Search for annotations on the specified target
+     * Search for annotations on the specified target, ordered by schema:position attribute.
      * 
      * @param {string} targetUri URI of the target to search for
      */


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1055
  - Reload annotations from storage after saving, in order to ensure sanitized HTML shows up immediately on save
  - Revise sorting: only sort annotations returned from Annotorious; assume storage-retrieved annotations are already sorted correctly per https://github.com/Princeton-CDH/geniza/pull/1072/commits/fe1d231d5f3f137fd755668397978a7008c85bd7. Seems sometimes Annotorious `getAnnotations` returns them in a different order right after saving.
  - Use Annotorious [convenience update-and-save option](https://recogito.github.io/guides/headless-mode/#updateselected-and-saveselected) to ensure save completes before reloading