### PR TITLE
Only display drop zone when targeted or targetable

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,12 +1,14 @@
 .tahqiq-drop-zone {
     width: 100%;
     height: 100%;
-    display: block;
+    display: none; // Only display when targeted or targetable
     border: none;
     &.tahqiq-drag-targetable {
         border: 1px solid rgba(128, 128, 128, 0.5);
+        display: block;
     }
     &.tahqiq-drag-target {
         border: 2px dashed rgba(128, 128, 128, 0.5);
+        display: block;
     }
 }


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1057#issuecomment-1252564787:
  - Only display drop zone when targeted or targetable
