### PR TITLE
Make secondary motivation configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -308,10 +308,6 @@ class TranscriptionEditor {
     async handleSaveAnnotation(annotationBlock: AnnotationBlock) {
         const annotation = annotationBlock.annotation;
         const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
-        // add primary and secondary (if applicable) motivation to the annotation
-        annotation.motivation = this.storage.settings.secondaryMotivation
-            ? ["sc:supplementing", this.storage.settings.secondaryMotivation]
-            : "sc:supplementing";
         // add the content to the annotation
         if (Array.isArray(annotation.body) && annotation.body.length == 0) {
             annotation.body.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,7 +319,6 @@ class TranscriptionEditor {
                 // - purpose on body is only needed if more than one body
                 //   (e.g., transcription + tags in the same annotation)
             });
-            // TODO: transcription language, etc.
         } else if (Array.isArray(annotation.body)) {
             // assume text content is first body element
             annotation.body[0].value = editorContent || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,17 +308,22 @@ class TranscriptionEditor {
     async handleSaveAnnotation(annotationBlock: AnnotationBlock) {
         const annotation = annotationBlock.annotation;
         const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
+        // add primary and secondary (if applicable) motivation to the annotation
+        annotation.motivation = this.storage.settings.secondaryMotivation
+            ? ["sc:supplementing", this.storage.settings.secondaryMotivation]
+            : "sc:supplementing";
         // add the content to the annotation
-        annotation.motivation = "supplementing";
         if (Array.isArray(annotation.body) && annotation.body.length == 0) {
             annotation.body.push({
                 type: "TextualBody",
-                purpose: "transcribing",
                 value: editorContent || "",
                 format: "text/html",
                 label: annotationBlock.labelElement.textContent || undefined,
-                // TODO: transcription motivation, language, etc.
+                // purpose: "transcribing",
+                // - purpose on body is only needed if more than one body
+                //   (e.g., transcription + tags in the same annotation)
             });
+            // TODO: transcription language, etc.
         } else if (Array.isArray(annotation.body)) {
             // assume text content is first body element
             annotation.body[0].value = editorContent || "";

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -79,6 +79,11 @@ class AnnotationServerStorage {
             annotation["dc:source"] = this.settings.sourceUri;
         }
 
+        // save primary and secondary (if applicable) motivation on annotation
+        annotation.motivation = this.settings.secondaryMotivation
+            ? ["sc:supplementing", this.settings.secondaryMotivation]
+            : "sc:supplementing";
+
         // increment annotation count and set position attribute
         this.setAnnotationCount(this.annotationCount + 1);
         if (!annotation["schema:position"]) {

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -10,7 +10,7 @@ interface Annotation {
     body: Body | Body[];
     "dc:source"?: string;
     id?: string;
-    motivation: string;
+    motivation: string | string[];
     "schema:position"?: number | null;
     target: Target;
     type: string;

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -10,7 +10,7 @@ interface Annotation {
     body: Body | Body[];
     "dc:source"?: string;
     id?: string;
-    motivation: string | string[];
+    motivation?: string | string[];
     "schema:position"?: number | null;
     target: Target;
     type: string;

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -6,6 +6,7 @@ interface Settings {
     target: string;
     manifest: string;
     csrf_token: string;
+    secondaryMotivation?: string;
     sourceUri?: string;
 }
 


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1123:
  - Add motivation `sc:supplementing` to annotations
  - Make secondary motivation configurable in storage
  - Remove and document `purpose` on annotation body