### PR TITLE
Handle Annotorious cancellation events

### DIFF
--- a/src/elements/CancelButton.ts
+++ b/src/elements/CancelButton.ts
@@ -22,25 +22,40 @@ class CancelButton extends HTMLButtonElement {
         this.textContent = "Cancel";
 
         // Attach click handler
-        this.addEventListener("click", this.handleClick.bind(this));
+        this.addEventListener("click", this.handleCancel.bind(this));
+        // Attach annotorious cancelSelected event handler
+        document.addEventListener(
+            "cancel-annotation",
+            this.handleCancel.bind(this),
+        );
     }
 
     /**
-     * On click, cancel edit/create annotation.
+     * On click or cancel from Annotorious, cancel edit/create annotation.
      *
-     * @param {Event} evt Click event
+     * @param {Event|CustomEvent} evt Click event
      */
-    handleClick(evt: Event) {
+    handleCancel(evt: Event | CustomEvent) {
         // cancel the edit
         evt.stopPropagation(); // ensure parent onClick event isn't called
-        // clear the selection from the image
-        this.annotationBlock.onCancel();
-        if (this.annotationBlock.annotation.id) {
-            // if annotation was saved previously, restore and make read only
-            this.annotationBlock.makeReadOnly(true);
-        } else {
-            // if this was a new annotation, remove the displayBlock
-            this.annotationBlock.remove();
+
+        // if this was cancelled by annotorious, should dispatch CustomEvent with a Selection in the
+        // CustomEvent.details targeting the same canvas as this.annotationBlock.annotation
+        const cancelledByAnnotorious =
+            evt instanceof CustomEvent &&
+            evt.detail?.target?.source ===
+                this.annotationBlock.annotation.target.source;
+        // if this was a click event or it was cancelled by annotorious, cancel!
+        if (!(evt instanceof CustomEvent) || cancelledByAnnotorious) {
+            // clear the selection from the image
+            this.annotationBlock.onCancel();
+            if (this.annotationBlock.annotation.id) {
+                // if annotation was saved previously, restore and make read only
+                this.annotationBlock.makeReadOnly(true);
+            } else {
+                // if this was a new annotation, remove the displayBlock
+                this.annotationBlock.remove();
+            }
         }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,19 @@ class TranscriptionEditor {
             this.handleChangeSelectionTarget.bind(this),
         );
 
+        // when Annotorious cancels an annotation, we should too
+        this.anno.on(
+            "cancelSelected",
+            (selection: Selection) => {
+                // pass selection as CustomEvent.detail so we can cancel the right one
+                // (e.g. if there are multiple annotations being edited on different canvases
+                // at once)
+                document.dispatchEvent(
+                    new CustomEvent("cancel-annotation", { detail: selection }),
+                );
+            },
+        );
+
         // Prepare tinyMCE editor custom element and config
         if (!customElements.get("tinymce-editor")) {
             Editor();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -60,7 +60,7 @@ describe("Plugin instantiation", () => {
         new TranscriptionEditor(clientMock, storageMock, container, "fakeTinyMceKey");
         expect(addEventListenerSpy).toBeCalledTimes(2);
         // should also attach even listeners to client events
-        expect(clientMock.on).toBeCalledTimes(3);
+        expect(clientMock.on).toBeCalledTimes(4);
     });
     it("Should define custom elements on initialization", () => {
         new TranscriptionEditor(clientMock, storageMock, container, "fakeTinyMceKey");


### PR DESCRIPTION
## In this PR

- Fix a bug where canceling an Annotorious annotation by clicking outside of its bounding box would _not_ cancel editing the annotation text
  - Dispatch our own custom event on the entire `document` when Annotorious raises its `cancelSelected` event, passing along the canvas data in `CustomEvent.details`, and handle the document event in each `CancelButton` in order to match the canvas to the appropriate annotation editor before proceeding with the `CancelButton`'s normal logic

See also https://github.com/Princeton-CDH/geniza/issues/1131, https://github.com/recogito/annotorious/issues/228