### PR TITLE
Fix bugs with Annotorious cancellation and annotations-loaded

### DIFF
--- a/src/elements/CancelButton.ts
+++ b/src/elements/CancelButton.ts
@@ -41,10 +41,15 @@ class CancelButton extends HTMLButtonElement {
 
         // if this was cancelled by annotorious, should dispatch CustomEvent with a Selection in the
         // CustomEvent.details targeting the same canvas as this.annotationBlock.annotation
+        let thisSource = this.annotationBlock.annotation.target.source;
+        if (typeof thisSource !== "string") thisSource = thisSource.id;
         const cancelledByAnnotorious =
             evt instanceof CustomEvent &&
-            evt.detail?.target?.source ===
-                this.annotationBlock.annotation.target.source;
+            // handle target source of types string and Source
+            (
+                evt.detail?.target?.source === thisSource ||
+                evt.detail?.target?.source?.id === thisSource
+            );
         // if this was a click event or it was cancelled by annotorious, cancel!
         if (!(evt instanceof CustomEvent) || cancelledByAnnotorious) {
             // clear the selection from the image

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,9 +2,6 @@ import type { Annotation, SavedAnnotation } from "./types/Annotation";
 import type { Source } from "./types/Source";
 import type { Settings } from "./types/Settings";
 
-// define a custom event to indicate that annotations have been loaded
-const AnnoLoadEvent = new Event("annotations-loaded");
-
 // TODO: Add a typedef for the Annotorious client (anno)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 /**
@@ -59,7 +56,10 @@ class AnnotationServerStorage {
         if (annotations instanceof Array) {
             this.annotationCount = annotations.length;
         }
-        setTimeout(() => document.dispatchEvent(AnnoLoadEvent), 100);
+        setTimeout(() => document.dispatchEvent(
+            // include target with annotations-loaded event to match canvases
+            new CustomEvent("annotations-loaded", { detail: this.settings.target }),
+        ), 100);
         return annotations;
     }
 
@@ -100,7 +100,10 @@ class AnnotationServerStorage {
         this.anno.addAnnotation(newAnnotation);
 
         // reload annotations
-        document.dispatchEvent(AnnoLoadEvent);
+        document.dispatchEvent(
+            // include target with annotations-loaded event to match canvases
+            new CustomEvent("annotations-loaded", { detail: this.settings.target }),
+        );
         return Promise.resolve(newAnnotation);
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -51,6 +51,9 @@ const storageMock = {
     delete: jest.fn(),
     loadAnnotations: jest.fn(),
     update: jest.fn(),
+    settings: {
+        target: "canvas1",
+    },
 };
 const container = document.createElement("annotation-block");
 
@@ -76,7 +79,9 @@ describe("Set annotations draggable", () => {
         const editor = new TranscriptionEditor(
             clientMock, storageMock, container, "fakeTinyMceKey",
         );
-        editor.handleAnnotationsLoaded();
+        editor.handleAnnotationsLoaded(
+            new CustomEvent("annotations-loaded", { detail: "canvas1" }),
+        );
         editor.setAllDraggability(false);
         const blocks = editor.annotationContainer.querySelectorAll("annotation-block");
         blocks.forEach((block) => {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -75,7 +75,7 @@ describe("Storage instantiation", () => {
         // Should dispatch the event "annotations-loaded" after 100ms
         await new Promise((res) => setTimeout(res, 100));
         expect(dispatchEventSpy).toHaveBeenCalledWith(
-            new Event("annotations-loaded"),
+            new CustomEvent("annotations-loaded", { detail: settings.target }),
         );
     });
     it("Should call setAnnotations with the fake annotation in an array", async () => {


### PR DESCRIPTION
## In this PR

- When canceling via Annotorious, ensure that sources of types string and Source are both matched against annotations being edited, so that the correct editor is closed
  - Fixes a bug where sometimes the editor would not be closed when canceling via Annotorious.
- Match canvas on `annotations-loaded` event so that it doesn't reload annotations for canvases other than the one associated with the instance that dispatched the event
  - This is what caused the apparent "duplicate annotations" when scrolling down to the next canvas during editing. It was a regression introduced by the use of the observable pattern.
- Destroy all blocks on reload, even editors, before generating read-only blocks from the loaded annotations
  - Otherwise, Annotorious could theoretically become out of sync with annotation text blocks—however, reload shouldn't happen when an editor is open anyway, due to the aforementioned canvas-matching logic. This is just a contingency behavior in case that does ever happen.

Note: Helpful to hide whitespace when looking at the GitHub diff.

## Questions

- I did notice that sometimes the [`cancelSelected` event](https://recogito.github.io/annotorious/api-docs/osd-plugin/#cancelselected-1) doesn't seem to be raised by Annotorious when clicking outside of the annotation block. Specifically, if you move or resize the annotation block in Annotorious, and then click outside of it, the event is never raised. I think this is an upstream bug with Annotorious OSD—should I open an issue there?