### PR TITLE
Fix loading and query filtering issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,16 +148,16 @@ class TranscriptionEditor {
      */
     async handleAnnotationsLoaded(e: Event) {
         // only reload if the event target (i.e. canvas) matches this one
-        if (e instanceof CustomEvent && e.detail === this.storage?.settings?.target) {
+        if (e instanceof CustomEvent && e.detail?.target === this.storage?.settings?.target) {
             // remove any existing annotation blocks and drop zones, in case of update
             this.annotationContainer
                 .querySelectorAll("[class^='tahqiq-block']")
                 .forEach((el) => el.remove());
             this.annotationContainer.querySelector(".tahqiq-drop-zone")?.remove();
             // display all current annotations
-            const currentAnnotations = await this.anno.getAnnotations();
-            // sort by position attribute if present (sometimes annotorious gets these out of order)
-            if (currentAnnotations)
+            const currentAnnotations = e.detail.annotations;
+            if (currentAnnotations) {
+                // sort by position attribute if present
                 currentAnnotations.sort((a: Annotation, b: Annotation) => {
                     // null position should go to the end; it means dragged from another canvas
                     if (a["schema:position"] === null) return 1;
@@ -166,21 +166,23 @@ class TranscriptionEditor {
                         return a["schema:position"] - b["schema:position"];
                     return 0;
                 });
-            currentAnnotations.forEach((annotation: Annotation) => {
-                this.annotationContainer.append(
-                    new AnnotationBlock({
-                        annotation,
-                        editable: false,
-                        onCancel: this.handleCancel.bind(this),
-                        onClick: this.handleClickAnnotationBlock.bind(this),
-                        onDelete: this.handleDeleteAnnotation.bind(this),
-                        onDrag: this.handleDrag.bind(this),
-                        onReorder: this.handleDropAnnotationBlock.bind(this),
-                        onSave: this.handleSaveAnnotation.bind(this),
-                        updateAnnotorious: this.anno.addAnnotation,
-                    }),
-                );
-            });
+                // append annotation blocks to display current annotations
+                currentAnnotations.forEach((annotation: Annotation) => {
+                    this.annotationContainer.append(
+                        new AnnotationBlock({
+                            annotation,
+                            editable: false,
+                            onCancel: this.handleCancel.bind(this),
+                            onClick: this.handleClickAnnotationBlock.bind(this),
+                            onDelete: this.handleDeleteAnnotation.bind(this),
+                            onDrag: this.handleDrag.bind(this),
+                            onReorder: this.handleDropAnnotationBlock.bind(this),
+                            onSave: this.handleSaveAnnotation.bind(this),
+                            updateAnnotorious: this.anno.addAnnotation,
+                        }),
+                    );
+                });
+            }
             // if no annotations returned, append a drop zone here so we can drop annotations
             // from other canvases onto this one
             if (!currentAnnotations?.length) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -56,10 +56,16 @@ class AnnotationServerStorage {
         if (annotations instanceof Array) {
             this.annotationCount = annotations.length;
         }
-        setTimeout(() => document.dispatchEvent(
-            // include target with annotations-loaded event to match canvases
-            new CustomEvent("annotations-loaded", { detail: this.settings.target }),
-        ), 100);
+        document.dispatchEvent(
+            new CustomEvent("annotations-loaded", {
+                detail: {
+                    // include target with event to match canvases
+                    target: this.settings.target,
+                    // include annotations here (annotorious might be briefly out of sync)
+                    annotations,
+                },
+            }),
+        );
         return annotations;
     }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -224,15 +224,19 @@ class AnnotationServerStorage {
      * @param {string} targetUri URI of the target to search for
      */
     async search(targetUri: string): Promise<void | SavedAnnotation[]> {
-        const { annotationEndpoint, sourceUri } = this.settings;
+        const { annotationEndpoint, sourceUri, manifest } = this.settings;
         const sourceQuery = sourceUri ? `&source=${sourceUri}` : "";
-        return fetch(`${annotationEndpoint}search/?uri=${targetUri}${sourceQuery}`, {
-            headers: {
-                Accept: "application/json",
-                "Content-Type": "application/json",
-                "X-CSRFToken": this.settings.csrf_token,
+        const manifestQuery = manifest ? `&manifest=${manifest}` : "";
+        return fetch(
+            `${annotationEndpoint}search/?uri=${targetUri}${sourceQuery}${manifestQuery}`,
+            {
+                headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": this.settings.csrf_token,
+                },
             },
-        })
+        )
             .then(response => response.json())
             .then(data => <SavedAnnotation[]>data.resources);
         //     .catch(() => this.all());


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1129:
  - On load, pass annotations received from the server directly through the `annotations-loaded` event (instead of setting and then immediately getting from Annotorious) to populate annotation blocks
- Per https://github.com/Princeton-CDH/geniza/issues/1148:
  - Pass manifest to annotations search query to ensure it is filtered by PGPID