### PR TITLE
Fix issue with loading annotations on create

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -106,6 +106,7 @@ class AnnotationServerStorage {
         this.anno.addAnnotation(newAnnotation);
 
         // reload annotations
+        // TODO: Avoid extra network request here
         await this.loadAnnotations();
         return Promise.resolve(newAnnotation);
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -106,10 +106,7 @@ class AnnotationServerStorage {
         this.anno.addAnnotation(newAnnotation);
 
         // reload annotations
-        document.dispatchEvent(
-            // include target with annotations-loaded event to match canvases
-            new CustomEvent("annotations-loaded", { detail: this.settings.target }),
-        );
+        await this.loadAnnotations();
         return Promise.resolve(newAnnotation);
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -80,7 +80,12 @@ describe("Set annotations draggable", () => {
             clientMock, storageMock, container, "fakeTinyMceKey",
         );
         editor.handleAnnotationsLoaded(
-            new CustomEvent("annotations-loaded", { detail: "canvas1" }),
+            new CustomEvent("annotations-loaded", {
+                detail: {
+                    target: "canvas1",
+                    annotations: [fakeAnnotation],
+                },
+            }),
         );
         editor.setAllDraggability(false);
         const blocks = editor.annotationContainer.querySelectorAll("annotation-block");


### PR DESCRIPTION
## In this PR

- Fix issue with reloading annotations on create; the `annotations-loaded` event now requires the full list of annotations. Instead of dispatching that event directly, I now call the entire `loadAnnotations()` method on create.

## Questions

- Are we ok with the additional network request on create here, or should I find a way to avoid that?