### PR TITLE
Prevent Annotorious event/async race condition on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.0.1
+
+Bug fixes and minor improvements.
+
+### Bug fixes
+
+- Prevent a race condition on saving and retrieving annotations
+
 ## 1.0.0
 
 Initial public release of annotorious-tahqiq.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "annotorious-tahqiq",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A custom Annotorious editor/view plugin ",
     "main": "./dist/index.js",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ class TranscriptionEditor {
                 this.annotationContainer.append(dropZone);
             }
         }
+        this.setAllDraggability(true);
     }
 
     /**
@@ -301,8 +302,8 @@ class TranscriptionEditor {
                 this.storage.setAnnotationCount(this.storage.annotationCount - 1);
                 // remove the edit/display displayBlock
                 annotationBlock.remove();
-                // calling removeAnnotation doesn't fire the deleteAnnotation,
-                // so we have to trigger the deletion explicitly
+                // calling removeAnnotation doesn't fire the deleteAnnotation event,
+                // so we have to trigger the deletion explicitly (also avoids race condition!)
                 await this.storage.delete(annotationBlock.annotation);
                 // reload positions of all annotation blocks except this one
                 const blocks = this.annotationContainer.querySelectorAll(".tahqiq-block-display");
@@ -346,17 +347,9 @@ class TranscriptionEditor {
                 annotation.body[0].label = annotationBlock.labelElement.textContent;
             }
         }
-        // update with annotorious and save to storage backend
+        this.setAllDraggability(false);
+        // update with annotorious, save to, and reload from storage backend
         await this.anno.updateSelected(annotation, true);
-        // update annotation block with new annotation and set inactive
-        annotationBlock.setAnnotation(annotation);
-        annotationBlock.makeReadOnly();
-        // reload annotations from storage (for post-save effects e.g. html sanitization)
-        await this.storage.loadAnnotations();
-        // make all annotations draggable again
-        this.setAllDraggability(true);
-        // remove any drop zones if present
-        this.annotationContainer.querySelector(".tahqiq-drop-zone")?.remove();
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,6 +347,7 @@ class TranscriptionEditor {
                 annotation.body[0].label = annotationBlock.labelElement.textContent;
             }
         }
+        // turn off draggability for all blocks while saving
         this.setAllDraggability(false);
         // update with annotorious, save to, and reload from storage backend
         await this.anno.updateSelected(annotation, true);

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -197,21 +197,30 @@ describe("Event handlers", () => {
             type: "Annotation",
         };
 
-        fetchMock.mockResponseOnce(
-            JSON.stringify({
-                ...fakeAnnotation,
-                id: "oldId",
-            }),
-            {
-                status: 200,
-                statusText: "ok",
-            },
-        );
         const newAnnotation = {
             ...originalAnnotation,
             id: "assignedId",
             target: { source: "fakesource" },
         };
+        fetchMock.mockResponses(
+            [
+                JSON.stringify({
+                    ...fakeAnnotation,
+                    id: "oldId",
+                }),
+                {
+                    status: 200,
+                    statusText: "ok",
+                },
+            ],
+            [
+                JSON.stringify({ resources: [newAnnotation] }),
+                {
+                    status: 200,
+                    statusText: "ok",
+                },
+            ],
+        );
         clientMock.emit("updateAnnotation", annotation, previous);
         // should call addAnnotation on client
         expect(clientMock.addAnnotation).toHaveBeenCalledWith(newAnnotation);
@@ -228,10 +237,22 @@ describe("Event handlers", () => {
         );
         const storage = new AnnotationServerStorage(clientMock, settings);
 
-        fetchMock.mockResponseOnce(JSON.stringify({}), {
-            status: 200,
-            statusText: "ok",
-        });
+        fetchMock.mockResponses(
+            [
+                JSON.stringify({}),
+                {
+                    status: 200,
+                    statusText: "ok",
+                },
+            ],
+            [
+                JSON.stringify({ resources: [] }),
+                {
+                    status: 200,
+                    statusText: "ok",
+                },
+            ],
+        );
 
         clientMock.emit("deleteAnnotation", fakeAnnotation);
         // should call adapter.delete


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/1176:
  - Prevent race condition by only pulling from storage and updating display _after_ storage `save` Promise has resolved.
  - Add comment about how race condition is prevented already for deletion with our "delete" button
    - Not sure we actually ever call `storage.handleDeleteAnnotation` because the `deleteAnnotation` event doesn't get fired by our "delete" button, but maybe there's a key command in Annotorious? Either way, I also prevented the race condition there!
- Bump version to 1.0.1

## Notes/questions

- How should we handle versioning for dev? My thinking was that we bump the version number now, and once we're ready to deploy on QA, we can actually publish it on npm but use [dist-tags](https://docs.npmjs.com/adding-dist-tags-to-packages) to mark it as `develop` or similar. Alternatively, we could just use commit hashes like before.
- Going to handle error reporting separately because I think it will be easier to review this without it. I found this really simple [toast notification codepen](https://codepen.io/dcode-software/pen/BaaeYZa?editors=1111) that I think I'll adapt; the simplest solution I could find!