### PR TITLE
Alert info, error, and success messages with a custom event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Bug fixes and minor improvements.
 
 - Prevent a race condition on saving and retrieving annotations
 
+### Features
+
+- Raise alert events for info, error, and success statuses
+
 ## 1.0.0
 
 Initial public release of annotorious-tahqiq.

--- a/README.md
+++ b/README.md
@@ -22,16 +22,39 @@ This project uses [Volta](https://volta.sh/) to pin Node and NPM versions.
 This plugin can be installed with NPM:
 
 ```sh
-npm install --save https://github.com/Princeton-CDH/annotorious-tahqiq.git
+npm install --save annotorious-tahqiq
 ```
 
 Then, to use alongside Annotorious and a storage plugin:
 
 ```js
+import {
+  TranscriptionEditor,
+  AnnotationServerStorage,
+} from "annotorious-tahqiq";
+
+// Initialize Annotorious with your settings
 const client = Annotorious(annotoriousSettings);
-const storagePlugin = StoragePlugin(); // An Annotorious plugin for storing annotations
-const annotationContainer = document.getElementById("annotation"); // An empty HTML element that the editor will be placed into.
-const tinyApiKey = "1234567890"; // Your TinyMCE editor API key (optional, can be omitted for testing purposes).
+
+// Initialize annotorious-tahqiq storage plugin
+const storageSettings = {
+    annotationEndpoint,   // Endpoint of the annotation store
+    target,               // Target for annotations (typically, a IIIF canvas)
+    manifest,             // IIIF manifest that target is a part of
+    csrf_token,           // CSRF token for communication with annotation store
+    secondaryMotivation,  // Optional secondary motivation for annotations
+                          // (primary is "sc:supplementing")
+    sourceUri,            // Optional "dc:source" URI attribute for annotations
+};
+const storagePlugin = AnnotationServerStorage(client, storageSettings);
+
+// Locate an empty HTML element that the editor will be placed into
+const annotationContainer = document.getElementById("annotation");
+
+// Your TinyMCE editor API key (optional, can be omitted for testing purposes)
+const tinyApiKey = "1234567890";
+
+// Initalize annotorious-tahqiq editor
 new TranscriptionEditor(client, storagePlugin, annotationContainer, tinyApiKey);
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ This plugin exposes the following CSS classes that can be used to style its elem
   - `.tahqiq-drop-zone`: When running multiple instances of Tahqiq on the same page, this `div` will appear on an instance that has no annotations when the user begins dragging an annotation from another instance 
   - `.tahqiq-loading`: To compensate for network request timing, this class is added to all annotation containers after a drag and drop is completed, and removed when the network requests are finished
 
+
+### Events
+
+This plugin also raises custom events to report errors and other messages.
+
+- `tahqiq-alert`: A [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) with a `detail` object containing `message`, `status`, and `target`. `message` is an info, success, or error message; `status` is one of "info", "success", or "error"; and `target` is the target set in the settings for the storage plugin.
+
 ## Development
 
 ### Getting started

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This plugin can be installed with NPM:
 npm install --save annotorious-tahqiq
 ```
 
+or to install a specific version number:
+
+```sh
+npm install --save annotorious-tahqiq@1.0.1
+```
+
 Then, to use alongside Annotorious and a storage plugin:
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,7 @@ class TranscriptionEditor {
      * @param {HTMLElement} annotationBlock Annotation block associated with the annotation to save.
      */
     async handleSaveAnnotation(annotationBlock: AnnotationBlock) {
-        this.storage.alert("Saving annotation");
+        this.storage.alert("Saving...");
         const annotation = annotationBlock.annotation;
         const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
         // add the content to the annotation
@@ -479,7 +479,6 @@ class TranscriptionEditor {
         const annotations = await this.storage.loadAnnotations();
         try {
             await this.updateSequence(annotations);
-            this.storage.alert("Annotations reordered", "success");
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
             // handle errors thrown by storage.update in updateSequence

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,6 +290,7 @@ class TranscriptionEditor {
      */
     async handleDeleteAnnotation(annotationBlock: AnnotationBlock) {
         try {
+            this.storage.alert("Deleting...");
             if (!annotationBlock.annotation.id) {
                 this.storage.alert(
                     "No annotation ID associated with this display block",
@@ -420,6 +421,7 @@ class TranscriptionEditor {
             anno?.id === draggedId,
         );
         if (draggedAnnotation && evt.currentTarget instanceof AnnotationBlock) {
+            this.storage.alert("Reordering...");
             // dragged block found in current tahqiq instance
             const draggedIndex = annotations.indexOf(draggedAnnotation);
             const droppedIndex = annotations.indexOf(evt.currentTarget.annotation);
@@ -436,6 +438,7 @@ class TranscriptionEditor {
             }
         } else {
             // dragged block is from another tahqiq instance on the document
+            this.storage.alert("Moving...");
             const draggedBlock = document.querySelector(
                 `[data-annotation-id="${draggedId}"]`,
             );

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,9 +291,9 @@ class TranscriptionEditor {
     async handleDeleteAnnotation(annotationBlock: AnnotationBlock) {
         try {
             if (!annotationBlock.annotation.id) {
-                // TODO: Better error handling
-                throw new Error(
-                    "No annotation ID associated with this display block.",
+                this.storage.alert(
+                    "No annotation ID associated with this display block",
+                    "error",
                 );
             } else {
                 // remove the highlight zone from the image
@@ -313,10 +313,12 @@ class TranscriptionEditor {
                         return block.annotation;
                 });
                 await this.updateSequence(annotations);
+                this.storage.alert("Annotation deleted", "success");
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
-            console.error(err.message);
+            // handle errors thrown by storage.delete
+            this.storage.alert(err.message, "error");
         }
     }
 
@@ -327,6 +329,7 @@ class TranscriptionEditor {
      * @param {HTMLElement} annotationBlock Annotation block associated with the annotation to save.
      */
     async handleSaveAnnotation(annotationBlock: AnnotationBlock) {
+        this.storage.alert("Saving annotation");
         const annotation = annotationBlock.annotation;
         const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
         // add the content to the annotation
@@ -423,7 +426,14 @@ class TranscriptionEditor {
             // move the dragged block to the correct index
             annotations.splice(draggedIndex, 1);
             annotations.splice(droppedIndex, 0, draggedAnnotation);
-            await this.updateSequence(annotations);
+            try {
+                await this.updateSequence(annotations);
+                this.storage.alert("Annotations reordered", "success");
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
+                // handle errors thrown by storage.update in updateSequence
+                this.storage.alert(err.message, "error");
+            }
         } else {
             // dragged block is from another tahqiq instance on the document
             const draggedBlock = document.querySelector(
@@ -444,10 +454,19 @@ class TranscriptionEditor {
                     },
                     "schema:position": null,
                 };
-                // update the dragged block in storage
-                await this.storage.update(newAnnotation);
-                // recalculate positions in both this and origin tahqiq instances
-                document.dispatchEvent(ReloadPositionsEvent);
+                try {
+                    // update the dragged block in storage
+                    await this.storage.update(newAnnotation);
+                    this.storage.alert("Annotation moved", "success");
+                    // recalculate positions in both this and origin tahqiq instances
+                    document.dispatchEvent(ReloadPositionsEvent);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } catch (err: any) {
+                    // handle errors thrown by storage.update
+                    this.storage.alert(err.message, "error");
+                }
+            } else {
+                this.storage.alert("Error finding the dragged annotation", "error");
             }
         }
     }
@@ -458,7 +477,14 @@ class TranscriptionEditor {
      */
     async handleReloadAllPositions() {
         const annotations = await this.storage.loadAnnotations();
-        await this.updateSequence(annotations);
+        try {
+            await this.updateSequence(annotations);
+            this.storage.alert("Annotations reordered", "success");
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            // handle errors thrown by storage.update in updateSequence
+            this.storage.alert(err.message, "error");
+        }
     }
 
     /**

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -51,22 +51,29 @@ class AnnotationServerStorage {
      * is initialized.
      */
     async loadAnnotations() {
-        const annotations: void | SavedAnnotation[] = await this.search(this.settings.target);
-        await this.anno.setAnnotations(annotations);
-        if (annotations instanceof Array) {
-            this.annotationCount = annotations.length;
+        try {
+            const annotations: void | SavedAnnotation[] = await this.search(
+                this.settings.target,
+            );
+            await this.anno.setAnnotations(annotations);
+            if (annotations instanceof Array) {
+                this.annotationCount = annotations.length;
+            }
+            document.dispatchEvent(
+                new CustomEvent("annotations-loaded", {
+                    detail: {
+                        // include target with event to match canvases
+                        target: this.settings.target,
+                        // include annotations here (annotorious might be briefly out of sync)
+                        annotations,
+                    },
+                }),
+            );
+            return annotations;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            this.alert(err.message, "error");
         }
-        document.dispatchEvent(
-            new CustomEvent("annotations-loaded", {
-                detail: {
-                    // include target with event to match canvases
-                    target: this.settings.target,
-                    // include annotations here (annotorious might be briefly out of sync)
-                    annotations,
-                },
-            }),
-        );
-        return annotations;
     }
 
     /**
@@ -76,39 +83,45 @@ class AnnotationServerStorage {
      *
      * @param {Annotation} annotation V3 (W3C) annotation
      */
-    async handleCreateAnnotation(annotation: Annotation): Promise<Annotation> {
-        annotation.target.source = this.adjustTargetSource(
-            annotation.target.source,
-        );
-        // save source URI to dc:source attribute on annotation
-        if (this.settings.sourceUri) {
-            annotation["dc:source"] = this.settings.sourceUri;
+    async handleCreateAnnotation(
+        annotation: Annotation,
+    ): Promise<Annotation | void> {
+        try {
+            annotation.target.source = this.adjustTargetSource(
+                annotation.target.source,
+            );
+            // save source URI to dc:source attribute on annotation
+            if (this.settings.sourceUri) {
+                annotation["dc:source"] = this.settings.sourceUri;
+            }
+
+            // save primary and secondary (if applicable) motivation on annotation
+            annotation.motivation = this.settings.secondaryMotivation
+                ? ["sc:supplementing", this.settings.secondaryMotivation]
+                : "sc:supplementing";
+
+            // increment annotation count and set position attribute
+            this.setAnnotationCount(this.annotationCount + 1);
+            if (!annotation["schema:position"]) {
+                annotation["schema:position"] = this.annotationCount;
+            }
+
+            // wait for adapter to return saved annotation from storage
+            const newAnnotation: Annotation = await this.create(annotation);
+            // remove the annotation with the provisional ID from Annotorious display
+            this.anno.removeAnnotation(annotation.id);
+            // add the saved annotation returned by storage to Annotorious display
+            this.anno.addAnnotation(newAnnotation);
+
+            // reload annotations
+            // TODO: Avoid extra network request here
+            await this.loadAnnotations();
+            this.alert("Annotation created", "success");
+            return await Promise.resolve(newAnnotation);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            this.alert(err.message, "error");
         }
-
-        // save primary and secondary (if applicable) motivation on annotation
-        annotation.motivation = this.settings.secondaryMotivation
-            ? ["sc:supplementing", this.settings.secondaryMotivation]
-            : "sc:supplementing";
-
-        // increment annotation count and set position attribute
-        this.setAnnotationCount(this.annotationCount + 1);
-        if (!annotation["schema:position"]) {
-            annotation["schema:position"] = this.annotationCount;
-        }
-
-        // wait for adapter to return saved annotation from storage
-        const newAnnotation: Annotation = await this.create(
-            annotation,
-        );
-        // remove the annotation with the provisional ID from Annotorious display
-        this.anno.removeAnnotation(annotation.id);
-        // add the saved annotation returned by storage to Annotorious display
-        this.anno.addAnnotation(newAnnotation);
-
-        // reload annotations
-        // TODO: Avoid extra network request here
-        await this.loadAnnotations();
-        return Promise.resolve(newAnnotation);
     }
 
     /**
@@ -121,7 +134,7 @@ class AnnotationServerStorage {
     async handleUpdateAnnotation(
         annotation: SavedAnnotation,
         previous: SavedAnnotation,
-    ): Promise<Annotation> {
+    ): Promise<Annotation | void> {
         // The posted annotation should have an @id which exists in the store
         // we want to keep the same id, so we update the new annotation with
         // the previous id before saving.
@@ -130,14 +143,20 @@ class AnnotationServerStorage {
         annotation.target.source = this.adjustTargetSource(
             annotation.target.source,
         );
-        const updatedAnnotation: SavedAnnotation = await this.update(
-            annotation,
-        );
-        // redisplay the updated annotation in annotorious
-        this.anno.addAnnotation(updatedAnnotation);
-        // reload annotations from storage (for post-save effects e.g. html sanitization)
-        await this.loadAnnotations();
-        return Promise.resolve(updatedAnnotation);
+        try {
+            const updatedAnnotation: SavedAnnotation = await this.update(
+                annotation,
+            );
+            // redisplay the updated annotation in annotorious
+            this.anno.addAnnotation(updatedAnnotation);
+            // reload annotations from storage (for post-save effects e.g. html sanitization)
+            await this.loadAnnotations();
+            this.alert("Annotation saved", "success");
+            return await Promise.resolve(updatedAnnotation);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            this.alert(err.message, "error");
+        }
     }
 
     /**
@@ -148,10 +167,16 @@ class AnnotationServerStorage {
      * id property that matches its id property in the store.
      */
     async handleDeleteAnnotation(annotation: SavedAnnotation): Promise<void> {
-        this.setAnnotationCount(this.annotationCount - 1);
-        await this.delete(annotation);
-        await this.loadAnnotations();
-        return Promise.resolve();
+        try {
+            this.setAnnotationCount(this.annotationCount - 1);
+            await this.delete(annotation);
+            await this.loadAnnotations();
+            this.alert("Annotation deleted", "success");
+            return await Promise.resolve();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            this.alert(err.message, "error");
+        }
     }
 
     /**
@@ -168,8 +193,8 @@ class AnnotationServerStorage {
      *
      * @param {Annotation} annotation V3 (W3C) annotation to save.
      */
-    async create(annotation: Annotation) : Promise<SavedAnnotation> {
-        return fetch(`${this.settings.annotationEndpoint}`, {
+    async create(annotation: Annotation): Promise<SavedAnnotation> {
+        const res = await fetch(`${this.settings.annotationEndpoint}`, {
             body: JSON.stringify(annotation),
             headers: {
                 Accept: "application/json",
@@ -177,9 +202,15 @@ class AnnotationServerStorage {
                 "X-CSRFToken": this.settings.csrf_token,
             },
             method: "POST",
-        })
-            .then((annotationResponse: Response) => annotationResponse.json());
-        //.catch(() => this.all());
+        });
+        // fetch won't automatically throw error on bad HTTP code, so check for ok
+        if (res.ok) {
+            return res.json();
+        } else {
+            throw new Error(
+                `Error creating annotation: ${res.status} ${res.statusText}`,
+            );
+        }
     }
 
     /**
@@ -187,9 +218,9 @@ class AnnotationServerStorage {
      *
      * @param {SavedAnnotation} annotation V3 (W3C) annotation to update.
      */
-    async update(annotation: SavedAnnotation) : Promise<SavedAnnotation> {
+    async update(annotation: SavedAnnotation): Promise<SavedAnnotation> {
         // post the revised annotation to its URI
-        return fetch(annotation.id, {
+        const res = await fetch(annotation.id, {
             body: JSON.stringify(annotation),
             headers: {
                 Accept: "application/json",
@@ -197,10 +228,14 @@ class AnnotationServerStorage {
                 "X-CSRFToken": this.settings.csrf_token,
             },
             method: "POST",
-        })
-            .then((annotationResponse: Response) => annotationResponse.json());
-        // .then(() => this.all())
-        // .catch(() => this.all());
+        });
+        if (res.ok) {
+            return res.json();
+        } else {
+            throw new Error(
+                `Error updating annotation: ${res.status} ${res.statusText}`,
+            );
+        }
     }
 
     /**
@@ -210,7 +245,7 @@ class AnnotationServerStorage {
      * @param {SavedAnnotation} annotation to delete
      */
     async delete(annotation: SavedAnnotation) {
-        return fetch(annotation.id, {
+        const res = await fetch(annotation.id, {
             headers: {
                 Accept: "application/json",
                 "Content-Type": "application/json",
@@ -218,21 +253,26 @@ class AnnotationServerStorage {
             },
             method: "DELETE",
         });
-        //     .then(() => this.all())
-        //     .catch(() => this.all());
+        if (res.ok) {
+            return res;
+        } else {
+            throw new Error(
+                `Error deleting annotation: ${res.status} ${res.statusText}`,
+            );
+        }
     }
 
     /**
      *
      * Search for annotations on the specified target, ordered by schema:position attribute.
-     * 
+     *
      * @param {string} targetUri URI of the target to search for
      */
     async search(targetUri: string): Promise<void | SavedAnnotation[]> {
         const { annotationEndpoint, sourceUri, manifest } = this.settings;
         const sourceQuery = sourceUri ? `&source=${sourceUri}` : "";
         const manifestQuery = manifest ? `&manifest=${manifest}` : "";
-        return fetch(
+        const res = await fetch(
             `${annotationEndpoint}search/?uri=${targetUri}${sourceQuery}${manifestQuery}`,
             {
                 headers: {
@@ -241,12 +281,16 @@ class AnnotationServerStorage {
                     "X-CSRFToken": this.settings.csrf_token,
                 },
             },
-        )
-            .then(response => response.json())
-            .then(data => <SavedAnnotation[]>data.resources);
-        //     .catch(() => this.all());
+        );
+        if (res.ok) {
+            const data = await res.json();
+            return <SavedAnnotation[]>data.resources;
+        } else {
+            throw new Error(
+                `Error retrieving annotations: ${res.status} ${res.statusText}`,
+            );
+        }
     }
-
 
     /**
      * Utility function to change a source string (Annotorious output) into a
@@ -272,8 +316,24 @@ class AnnotationServerStorage {
         return source;
     }
 
+    /**
+     * Raises a custom event, tahqiq-alert, with passed message/status and the
+     * target (i.e. canvas) with which this instance is associated.
+     *
+     * @param {string} message Message for the alert.
+     * @param {string} status Optional alert status.
+     */
+    alert(message: string, status?: string) {
+        document.dispatchEvent(
+            new CustomEvent("tahqiq-alert", {
+                detail: {
+                    message,
+                    status: status || "info",
+                    target: this.settings.target,
+                },
+            }),
+        );
+    }
 }
-
-
 
 export default AnnotationServerStorage;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -54,6 +54,7 @@ const storageMock = {
     settings: {
         target: "canvas1",
     },
+    alert: jest.fn(),
 };
 const container = document.createElement("annotation-block");
 


### PR DESCRIPTION
## In this PR

see also https://github.com/Princeton-CDH/geniza/pull/1196

- Per https://github.com/Princeton-CDH/geniza/issues/1176
  - Dispatch custom events for when asynchronous processes start ("info") and end ("success" or "error")
  - Tests for storage (but not for editor since we don't really have those yet…)
- Update readme with more detail about settings, proper reference to npm package

I recommend turning off whitespace during review, due to some things being wrapped in try/catch.