### PR TITLE
Give user a chance to stop cancel event when there are changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "keywords": [
         "annotorious",
         "transcription",
-        "annotation"
+        "annotation",
+        "right-to-left"
     ],
     "author": "The Center for Digital Humanities at Princeton <cdhdevteam@princeton.edu>",
     "license": "Apache-2.0",

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -18,6 +18,8 @@ class AnnotationBlock extends HTMLElement {
 
     labelElement: HTMLHeadingElement;
 
+    clickable: boolean;
+
     onCancel: () => void;
 
     onClick: (annotationBlock: AnnotationBlock) => void;
@@ -94,7 +96,11 @@ class AnnotationBlock extends HTMLElement {
         }
 
         // Set click event listener
+        this.clickable = true;
         this.addEventListener("click", () => {
+            // bail out if clicking disabled
+            if (! this.clickable) { return; }
+
             // if you click on this block, and it is in read-only mode, make editable
             if (!this.classList.contains("tahqiq-block-editor")) {
                 this.onClick(this);
@@ -264,6 +270,17 @@ class AnnotationBlock extends HTMLElement {
      */
     setDraggable(draggable: boolean): void {
         this.draggable = draggable;
+    }
+
+    /**
+     * Set whether or not this annotation block can be clicked
+     * to select. Should not be clickable when another block is
+     * being edited.
+     *
+     * @param {boolean} clickable Boolean indicating if this block is clickable
+     */
+    setClickable(clickable: boolean): void {
+        this.clickable = clickable;
     }
 }
 

--- a/src/elements/CancelButton.ts
+++ b/src/elements/CancelButton.ts
@@ -39,6 +39,22 @@ class CancelButton extends HTMLButtonElement {
         // cancel the edit
         evt.stopPropagation(); // ensure parent onClick event isn't called
 
+        // if a cancel is triggered but there are changes
+        // in the editor, give the user a chance to keep editing.
+        // NOTE: does not account for changes to label or annotation zone.
+        if (window.tinymce.activeEditor.isDirty()) {
+            if (
+                confirm(
+                    "You have unsaved changes. Do you want to keep editing?",
+                ) == true
+            ) {
+                // if they click ok, return and don't process the cancelation
+                return;
+            }
+        }
+        // if there are no changes or user clicked cancel,
+        // continue on to process the cancel
+
         // if this was cancelled by annotorious, should dispatch CustomEvent with a Selection in the
         // CustomEvent.details targeting the same canvas as this.annotationBlock.annotation
         let thisSource = this.annotationBlock.annotation.target.source;

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,20 @@ class TranscriptionEditor {
         this.anno.on(
             "cancelSelected",
             (selection: Selection) => {
+                // if a cancel is triggered but there are changes
+                // in the editor, give the user a chance to keep editing
+
+                // TODO: is there an equivalent check for annotation zone modified?
+                if (window.tinymce.activeEditor.isDirty()) {
+                    if (confirm("You have unsaved changes. Do you want to keep editing?") == true) {
+                        // if they click ok, return and don't process the cancelation
+                        // (do we need to undo the cancel in annotorious? doesn't seem like it)
+                        return;
+                    }
+                }
+                // if there are no changes or user clicked cancel,
+                // continue on to process the cancel
+
                 // pass selection as CustomEvent.detail so we can cancel the right one
                 // (e.g. if there are multiple annotations being edited on different canvases
                 // at once)

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ class TranscriptionEditor {
      * and sets one annotation block to editable corresponding to the selected annotation.
      *
      * @param {Annotation} annotation Annotorious annotation.
-     * @param {SVGElement} element Annotation SVG shape element.
+     * @param {HTMLElement} element Annotation SVG shape element.
      */
     handleSelectAnnotation(annotation: Annotation, element: HTMLElement) {
         // The user has selected an existing annotation

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,7 @@ class TranscriptionEditor {
         this.annotationContainer.append(annotationBlock);
         this.makeAllReadOnlyExcept(annotationBlock);
         this.setAllInteractive(false);
+        this.allowDragging(this.anno._element);
     }
 
     /**
@@ -244,14 +245,17 @@ class TranscriptionEditor {
      * and sets one annotation block to editable corresponding to the selected annotation.
      *
      * @param {Annotation} annotation Annotorious annotation.
+     * @param {SVGElement} element Annotation SVG shape element.
      */
-    handleSelectAnnotation(annotation: Annotation) {
+    handleSelectAnnotation(annotation: Annotation, element: HTMLElement) {
         // The user has selected an existing annotation
         // find the display element by annotation id and swith to edit mode
         const annotationBlock = document.querySelector(
             '[data-annotation-id="' + annotation.id + '"]',
         );
         if (annotationBlock && annotationBlock instanceof AnnotationBlock) {
+            // allow pointer events while the handles are being dragged
+            this.allowDragging(element);
             // make sure no other editor is active
             this.makeAllReadOnlyExcept(annotationBlock);
             annotationBlock.makeEditable();
@@ -587,6 +591,25 @@ class TranscriptionEditor {
                 selectedAnnotoriousRectangle.style.pointerEvents = "all";
             }
         }
+    }
+
+    /**
+     * When a selection is created or changed, this function will temporarily allow
+     * Annotorious pointer events while the selection's handles are being dragged.
+     *
+     * @param {HTMLElement} element The element containing the selection's handles.
+     */
+    allowDragging(element: HTMLElement) {
+        element.querySelectorAll("g.a9s-handle").forEach(
+            (handle) => {
+                handle.addEventListener(
+                    "mousedown", () => this.setAnnotoriousPointerEvents(true),
+                );
+                handle.addEventListener(
+                    "mouseup", () => this.setAnnotoriousPointerEvents(false),
+                );
+            },
+        );
     }
 
     /**

--- a/tests/elements/AnnotationBlock.test.ts
+++ b/tests/elements/AnnotationBlock.test.ts
@@ -74,6 +74,15 @@ describe("Click event", () => {
         expect(block.onClick).toHaveBeenCalledTimes(0);
         expect(block.makeEditable).toHaveBeenCalledTimes(0);
     });
+    it("Should do nothing if clickable is false", () => {
+        const block = new AnnotationBlock(props);
+        block.setClickable(false);
+
+        const evt = new MouseEvent("click");
+        block.dispatchEvent(evt);
+        expect(block.onClick).toHaveBeenCalledTimes(0);
+        expect(block.makeEditable).toHaveBeenCalledTimes(0);
+    });
 });
 
 describe("HTML encoding utility", () => {
@@ -99,4 +108,26 @@ describe("Drag event", () => {
         block.setDraggedOver(false);
         expect(block.classList.contains("tahqiq-drag-target")).toBe(false);
     });
+});
+
+describe("setDraggable", () => {
+
+    it("updates draggable when called", () => {
+        const block = new AnnotationBlock(props);
+        block.setDraggable(true);
+        expect(block.draggable).toEqual(true);
+        block.setDraggable(false);
+        expect(block.draggable).toEqual(false);
+    })
+});
+
+describe("setClickable", () => {
+
+    it("updates clickable when called", () => {
+        const block = new AnnotationBlock(props);
+        block.setClickable(false);
+        expect(block.clickable).toEqual(false);
+        block.setClickable(true);
+        expect(block.clickable).toEqual(true);
+    })
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -105,11 +105,12 @@ describe("Set annotations draggable", () => {
                 },
             }),
         );
-        editor.setAllDraggability(false);
+        editor.setAllInteractive(false);
         const blocks = editor.annotationContainer.querySelectorAll("annotation-block");
         blocks.forEach((block) => {
             if (block instanceof AnnotationBlock) {
                 expect(block.draggable).toBe(false);
+                expect(block.clickable).toBe(false);
             }
         });
     });
@@ -145,7 +146,7 @@ describe("Update annotations sequence", () => {
         const editor = new TranscriptionEditor(
             clientMock, storageMock, container, "fakeTinyMceKey",
         );
-        const draggabilitySpy = jest.spyOn(editor, "setAllDraggability");
+        const draggabilitySpy = jest.spyOn(editor, "setAllInteractive");
         storageMock.loadAnnotations.mockClear();
         await editor.updateSequence(fakeAnnotationList);
         expect(draggabilitySpy).toBeCalledWith(false);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -55,6 +55,12 @@ osdCanvas.className = "openseadragon-canvas";
 clientMock._element.appendChild(osdCanvas);
 const annotationLayer = document.createElement("svg");
 annotationLayer.className = "a9s-annotationlayer";
+const annotoriousRectangle = document.createElement("g");
+annotoriousRectangle.className = "a9s-annotation";
+annotationLayer.appendChild(annotoriousRectangle);
+const selectedRectangle = document.createElement("g");
+selectedRectangle.classList.add("a9s-annotation", "editable", "selected");
+annotationLayer.appendChild(selectedRectangle);
 clientMock._element.appendChild(annotationLayer);
 
 // Mock the storage plugin
@@ -189,10 +195,6 @@ describe("Reload all positions", () => {
 });
 
 describe("Handle cancelSelection event", () => {
-    afterEach(() => {
-        jest.clearAllMocks();  // clear counts after each test
-    });
-
     it("Should emit cancel-annotation", () => {
         const editor = new TranscriptionEditor(
             clientMock, storageMock, container, "fakeTinyMceKey",
@@ -202,5 +204,29 @@ describe("Handle cancelSelection event", () => {
         expect(dispatchEventSpy).toHaveBeenCalledWith(
             new CustomEvent("cancel-annotation", { detail: fakeAnnotation }),
         );
+    });
+});
+
+describe("Set annotorious pointer events", () => {
+    it("Should set pointer-events to auto/all when enabled is set true", () => {
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
+        editor.setAnnotoriousPointerEvents(true);
+        expect(osdCanvas.style.pointerEvents).toBe("auto");
+        expect(annotationLayer.style.pointerEvents).toBe("all");
+        expect(annotoriousRectangle.style.pointerEvents).toBe("all");
+    });
+    it("Should set pointer-events to none when enabled is set false", () => {
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
+        editor.setAnnotoriousPointerEvents(false);
+        expect(osdCanvas.style.pointerEvents).toBe("none");
+        expect(annotationLayer.style.pointerEvents).toBe("none");
+        expect(annotoriousRectangle.style.pointerEvents).toBe("none");
+
+        // should set selected rectangle pointer-events to "all"
+        expect(selectedRectangle.style.pointerEvents).toBe("all");
     });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,6 +57,9 @@ const annotationLayer = document.createElement("svg");
 annotationLayer.className = "a9s-annotationlayer";
 const annotoriousRectangle = document.createElement("g");
 annotoriousRectangle.className = "a9s-annotation";
+const handle = document.createElement("g");
+handle.className = "a9s-handle";
+annotoriousRectangle.appendChild(handle);
 annotationLayer.appendChild(annotoriousRectangle);
 const selectedRectangle = document.createElement("g");
 selectedRectangle.classList.add("a9s-annotation", "editable", "selected");
@@ -228,5 +231,29 @@ describe("Set annotorious pointer events", () => {
 
         // should set selected rectangle pointer-events to "all"
         expect(selectedRectangle.style.pointerEvents).toBe("all");
+    });
+});
+
+describe("Allow dragging selection handles", () => {
+    it("Should add event listeners to handles", () => {
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
+        const handleEventListenerSpy = jest.spyOn(handle, "addEventListener");
+        editor.allowDragging(annotoriousRectangle);
+        expect(handleEventListenerSpy).toHaveBeenCalledTimes(2);
+    });
+    it("Should respond to mousedown and mouseup with calls to setAnnotoriousPointerEvents", () => {
+        const editor = new TranscriptionEditor(
+            clientMock, storageMock, container, "fakeTinyMceKey",
+        );
+        const setPointerEventsSpy = jest.spyOn(editor, "setAnnotoriousPointerEvents");
+        editor.allowDragging(annotoriousRectangle);
+        let evt = new MouseEvent("mousedown");
+        handle.dispatchEvent(evt);
+        expect(setPointerEventsSpy).toHaveBeenCalled();
+        evt = new MouseEvent("mouseup");
+        handle.dispatchEvent(evt);
+        expect(setPointerEventsSpy).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
adds new logic to cancel event handler — if the currently active tiny editor has changes, open a confirmation prompt to give them a chance to opt out.

questions:
- should we have similar logic for changes to the annotation zone, in case of accidental cancellation?  (may matter more later when we have more complicated shapes)
- I would like to write a unit test, it doesn't look like we have one for the cancel handler right now — is that correct?