### PR TITLE
Add functionality for translations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ class TranscriptionEditor {
      * @param {any} storage Storage plugin to save Annotorious annotations.
      * @param {HTMLElement} annotationContainer Existing HTML element that the editor will be
      * placed into.
-     * @param {string} directionality Direction of the transcription content.
+     * @param {string} textDirection Text direction of the TinyMCE rich text editor.
      * @param {string} tinyApiKey API key for the TinyMCE rich text editor.
      */
     constructor(
@@ -58,7 +58,7 @@ class TranscriptionEditor {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         storage: any,
         annotationContainer: HTMLElement,
-        directionality: string,
+        textDirection?: string,
         tinyApiKey?: string,
     ) {
         this.anno = anno;
@@ -120,7 +120,7 @@ class TranscriptionEditor {
                 plugins: "lists",
                 toolbar:
                     "language | numlist | strikethrough superscript | undo redo | ",
-                directionality,
+                directionality: textDirection || "rtl",
                 formats: {
                     strikethrough: { inline: "del" },
                     // A custom format for insertion element

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,18 @@ class TranscriptionEditor {
      * @param {any} storage Storage plugin to save Annotorious annotations.
      * @param {HTMLElement} annotationContainer Existing HTML element that the editor will be
      * placed into.
+     * @param {string} directionality Direction of the transcription content.
      * @param {string} tinyApiKey API key for the TinyMCE rich text editor.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(anno: any, storage: any, annotationContainer: HTMLElement, tinyApiKey?: string) {
+    constructor(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        anno: any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        storage: any,
+        annotationContainer: HTMLElement,
+        directionality: string,
+        tinyApiKey?: string,
+    ) {
         this.anno = anno;
         this.storage = storage;
         // disable the default annotorious editor (headless mode)
@@ -112,7 +120,7 @@ class TranscriptionEditor {
                 plugins: "lists",
                 toolbar:
                     "language | numlist | strikethrough superscript | undo redo | ",
-                directionality: "rtl",
+                directionality,
                 formats: {
                     strikethrough: { inline: "del" },
                     // A custom format for insertion element

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -269,11 +269,15 @@ class AnnotationServerStorage {
      * @param {string} targetUri URI of the target to search for
      */
     async search(targetUri: string): Promise<void | SavedAnnotation[]> {
-        const { annotationEndpoint, sourceUri, manifest } = this.settings;
-        const sourceQuery = sourceUri ? `&source=${sourceUri}` : "";
-        const manifestQuery = manifest ? `&manifest=${manifest}` : "";
+        const { annotationEndpoint, sourceUri, manifest, secondaryMotivation } =
+            this.settings;
+        const sourceQ = sourceUri ? `&source=${sourceUri}` : "";
+        const manifestQ = manifest ? `&manifest=${manifest}` : "";
+        const motivationQ = secondaryMotivation
+            ? `&motivation=${secondaryMotivation}`
+            : "";
         const res = await fetch(
-            `${annotationEndpoint}search/?uri=${targetUri}${sourceQuery}${manifestQuery}`,
+            `${annotationEndpoint}search/?uri=${targetUri}${sourceQ}${manifestQ}${motivationQ}`,
             {
                 headers: {
                     Accept: "application/json",


### PR DESCRIPTION
## In this PR

Per https://github.com/Princeton-CDH/geniza/issues/1337:
- Allow TinyMCE `directionality` setting to be changed at instantiation; in the case of translations, it will be pulled from the SourceLanguage record
- Add secondary motivation (`translating` or `transcribing`) to search string, so that the API can filter on motivation, and thus retrieve only transcribing or translating annotations at a time