### PR TITLE
Support line grouping and editing for line-level annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
             "devDependencies": {
                 "@tsconfig/node16": "^1.0.2",
                 "@types/jest": "^27.5.0",
+                "@types/object.groupby": "^1.0.3",
                 "@typescript-eslint/eslint-plugin": "^5.22.0",
                 "@typescript-eslint/parser": "^5.22.0",
                 "autoprefixer": "^10.4.7",
@@ -1368,6 +1369,12 @@
             "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
             "dev": true
         },
+        "node_modules/@types/object.groupby": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/object.groupby/-/object.groupby-1.0.3.tgz",
+            "integrity": "sha512-C9QFoqjAaotcb9TIwYz55M5Psit4fP+j05Ro0sO/jeCtaFBJgE8ioqaob2Q82XhAWuNPlm6wtTFvbYa1Hpr11g==",
+            "dev": true
+        },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -1982,6 +1989,22 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+            "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.5",
+                "is-array-buffer": "^3.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/array-includes": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
@@ -2020,6 +2043,28 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.19.2",
                 "es-shim-unscopables": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arraybuffer.prototype.slice": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+            "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+            "dev": true,
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.1",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.22.3",
+                "es-errors": "^1.2.1",
+                "get-intrinsic": "^1.2.3",
+                "is-array-buffer": "^3.0.4",
+                "is-shared-array-buffer": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2074,6 +2119,18 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
+            "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/babel-jest": {
@@ -2267,13 +2324,14 @@
             "dev": true
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dev": true,
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2729,12 +2787,27 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/define-properties": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+        "node_modules/define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
             "dev": true,
             "dependencies": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "dependencies": {
+                "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             },
@@ -2888,31 +2961,50 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.19.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-            "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
+                "array-buffer-byte-length": "^1.0.0",
+                "arraybuffer.prototype.slice": "^1.0.2",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.5",
+                "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.1.1",
+                "function.prototype.name": "^1.1.6",
+                "get-intrinsic": "^1.2.2",
                 "get-symbol-description": "^1.0.0",
-                "has": "^1.0.3",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.3",
-                "is-callable": "^1.2.4",
+                "hasown": "^2.0.0",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
                 "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
                 "is-shared-array-buffer": "^1.0.2",
                 "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.12",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.0",
+                "object-inspect": "^1.13.1",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.2",
-                "string.prototype.trimend": "^1.0.4",
-                "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.1"
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.5.1",
+                "safe-array-concat": "^1.0.1",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.8",
+                "string.prototype.trimend": "^1.0.7",
+                "string.prototype.trimstart": "^1.0.7",
+                "typed-array-buffer": "^1.0.0",
+                "typed-array-byte-length": "^1.0.0",
+                "typed-array-byte-offset": "^1.0.0",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2921,11 +3013,34 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-module-lexer": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
             "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
             "dev": true
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.2.2",
+                "has-tostringtag": "^1.0.0",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/es-shim-unscopables": {
             "version": "1.0.0",
@@ -3820,6 +3935,15 @@
             "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
             "dev": true
         },
+        "node_modules/for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
+            "dependencies": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3868,16 +3992,46 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function.prototype.name": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "functions-have-names": "^1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -3898,14 +4052,19 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.3.tgz",
+            "integrity": "sha512-JIcZczvcMVE7AUOP+X72bh8HqHBRxFdz5PDHYtNG/lE3yk9b3KZBJlwFcTyPYjg3L4RLLmZJzvjxhaZVapxFrQ==",
             "dev": true,
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "es-errors": "^1.0.0",
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4001,6 +4160,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/globalthis": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "dev": true,
+            "dependencies": {
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4019,6 +4193,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/graceful-fs": {
@@ -4064,12 +4250,24 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "get-intrinsic": "^1.2.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4088,18 +4286,30 @@
             }
         },
         "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -4277,13 +4487,13 @@
             "dev": true
         },
         "node_modules/internal-slot": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.1.0",
-                "has": "^1.0.3",
+                "get-intrinsic": "^1.2.2",
+                "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             },
             "engines": {
@@ -4297,6 +4507,22 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-array-buffer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+            "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-arrayish": {
@@ -4346,9 +4572,9 @@
             }
         },
         "node_modules/is-callable": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
@@ -4547,6 +4773,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-typed-array": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+            "dev": true,
+            "dependencies": {
+                "which-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -4558,6 +4799,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -6095,9 +6342,9 @@
             "dev": true
         },
         "node_modules/object-inspect": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6113,14 +6360,14 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
+                "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             },
             "engines": {
@@ -6654,6 +6901,23 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "set-function-name": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -6785,6 +7049,24 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-array-concat": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+            "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.5",
+                "get-intrinsic": "^1.2.2",
+                "has-symbols": "^1.0.3",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6804,6 +7086,23 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+            "integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.5",
+                "get-intrinsic": "^1.2.2",
+                "is-regex": "^1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -6918,6 +7217,36 @@
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+            "dev": true,
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.2",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-function-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+            "dev": true,
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/shallow-clone": {
@@ -7109,29 +7438,46 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string.prototype.trimend": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-            "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/string.prototype.trimstart": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-            "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7576,6 +7922,71 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/typed-array-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-byte-offset": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+            "dev": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/typescript": {
             "version": "4.6.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -7885,6 +8296,25 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
+            "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+            "dev": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.6",
+                "call-bind": "^1.0.5",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9112,6 +9542,12 @@
             "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
             "dev": true
         },
+        "@types/object.groupby": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/object.groupby/-/object.groupby-1.0.3.tgz",
+            "integrity": "sha512-C9QFoqjAaotcb9TIwYz55M5Psit4fP+j05Ro0sO/jeCtaFBJgE8ioqaob2Q82XhAWuNPlm6wtTFvbYa1Hpr11g==",
+            "dev": true
+        },
         "@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -9573,6 +10009,16 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "array-buffer-byte-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+            "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.5",
+                "is-array-buffer": "^3.0.4"
+            }
+        },
         "array-includes": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
@@ -9604,6 +10050,22 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
+        "arraybuffer.prototype.slice": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+            "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+            "dev": true,
+            "requires": {
+                "array-buffer-byte-length": "^1.0.1",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.22.3",
+                "es-errors": "^1.2.1",
+                "get-intrinsic": "^1.2.3",
+                "is-array-buffer": "^3.0.4",
+                "is-shared-array-buffer": "^1.0.2"
+            }
+        },
         "astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -9629,6 +10091,12 @@
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
             }
+        },
+        "available-typed-arrays": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
+            "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==",
+            "dev": true
         },
         "babel-jest": {
             "version": "28.0.3",
@@ -9775,13 +10243,14 @@
             "dev": true
         },
         "call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             }
         },
         "callsites": {
@@ -10123,12 +10592,24 @@
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
-        "define-properties": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+        "define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
             "dev": true,
             "requires": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "requires": {
+                "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             }
@@ -10239,38 +10720,74 @@
             }
         },
         "es-abstract": {
-            "version": "1.19.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-            "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
             "dev": true,
             "requires": {
-                "call-bind": "^1.0.2",
+                "array-buffer-byte-length": "^1.0.0",
+                "arraybuffer.prototype.slice": "^1.0.2",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.5",
+                "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.1.1",
+                "function.prototype.name": "^1.1.6",
+                "get-intrinsic": "^1.2.2",
                 "get-symbol-description": "^1.0.0",
-                "has": "^1.0.3",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.3",
-                "is-callable": "^1.2.4",
+                "hasown": "^2.0.0",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
                 "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
                 "is-shared-array-buffer": "^1.0.2",
                 "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.12",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.0",
+                "object-inspect": "^1.13.1",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.2",
-                "string.prototype.trimend": "^1.0.4",
-                "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.1"
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.5.1",
+                "safe-array-concat": "^1.0.1",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.8",
+                "string.prototype.trimend": "^1.0.7",
+                "string.prototype.trimstart": "^1.0.7",
+                "typed-array-buffer": "^1.0.0",
+                "typed-array-byte-length": "^1.0.0",
+                "typed-array-byte-offset": "^1.0.0",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.13"
             }
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true
         },
         "es-module-lexer": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
             "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
             "dev": true
+        },
+        "es-set-tostringtag": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.2.2",
+                "has-tostringtag": "^1.0.0",
+                "hasown": "^2.0.0"
+            }
         },
         "es-shim-unscopables": {
             "version": "1.0.0",
@@ -10954,6 +11471,15 @@
             "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
             "dev": true
         },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -10985,15 +11511,33 @@
             "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true
+        },
+        "function.prototype.name": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "functions-have-names": "^1.2.3"
+            }
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "dev": true
         },
         "gensync": {
@@ -11009,14 +11553,16 @@
             "dev": true
         },
         "get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.3.tgz",
+            "integrity": "sha512-JIcZczvcMVE7AUOP+X72bh8HqHBRxFdz5PDHYtNG/lE3yk9b3KZBJlwFcTyPYjg3L4RLLmZJzvjxhaZVapxFrQ==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "es-errors": "^1.0.0",
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             }
         },
         "get-package-type": {
@@ -11079,6 +11625,15 @@
                 "type-fest": "^0.20.2"
             }
         },
+        "globalthis": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
+        },
         "globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -11091,6 +11646,15 @@
                 "ignore": "^5.2.0",
                 "merge2": "^1.4.1",
                 "slash": "^3.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3"
             }
         },
         "graceful-fs": {
@@ -11127,13 +11691,19 @@
             "dev": true
         },
         "has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
             "dev": true,
             "requires": {
-                "get-intrinsic": "^1.1.1"
+                "get-intrinsic": "^1.2.2"
             }
+        },
+        "has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "dev": true
         },
         "has-symbols": {
             "version": "1.0.3",
@@ -11142,12 +11712,21 @@
             "dev": true
         },
         "has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.2"
             }
         },
         "html-encoding-sniffer": {
@@ -11280,13 +11859,13 @@
             "dev": true
         },
         "internal-slot": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
             "dev": true,
             "requires": {
-                "get-intrinsic": "^1.1.0",
-                "has": "^1.0.3",
+                "get-intrinsic": "^1.2.2",
+                "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             }
         },
@@ -11295,6 +11874,16 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true
+        },
+        "is-array-buffer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+            "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1"
+            }
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -11331,9 +11920,9 @@
             }
         },
         "is-callable": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "dev": true
         },
         "is-core-module": {
@@ -11460,6 +12049,15 @@
                 "has-symbols": "^1.0.2"
             }
         },
+        "is-typed-array": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+            "dev": true,
+            "requires": {
+                "which-typed-array": "^1.1.14"
+            }
+        },
         "is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -11468,6 +12066,12 @@
             "requires": {
                 "call-bind": "^1.0.2"
             }
+        },
+        "isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -12660,9 +13264,9 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "dev": true
         },
         "object-keys": {
@@ -12672,14 +13276,14 @@
             "dev": true
         },
         "object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dev": true,
             "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
+                "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             }
         },
@@ -13039,6 +13643,17 @@
                 "resolve": "^1.9.0"
             }
         },
+        "regexp.prototype.flags": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "set-function-name": "^2.0.0"
+            }
+        },
         "regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -13119,11 +13734,34 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "safe-array-concat": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+            "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.5",
+                "get-intrinsic": "^1.2.2",
+                "has-symbols": "^1.0.3",
+                "isarray": "^2.0.5"
+            }
+        },
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true
+        },
+        "safe-regex-test": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+            "integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.5",
+                "get-intrinsic": "^1.2.2",
+                "is-regex": "^1.1.4"
+            }
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -13188,6 +13826,30 @@
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "set-function-length": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+            "dev": true,
+            "requires": {
+                "define-data-property": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.2",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.1"
+            }
+        },
+        "set-function-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+            "dev": true,
+            "requires": {
+                "define-data-property": "^1.0.1",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.0"
             }
         },
         "shallow-clone": {
@@ -13342,26 +14004,37 @@
                 "strip-ansi": "^6.0.1"
             }
         },
-        "string.prototype.trimend": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-            "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+        "string.prototype.trim": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
             }
         },
         "string.prototype.trimstart": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-            "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
             }
         },
         "strip-ansi": {
@@ -13658,6 +14331,53 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true
         },
+        "typed-array-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "typed-array-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "typed-array-byte-offset": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "typed-array-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            }
+        },
         "typescript": {
             "version": "4.6.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -13888,6 +14608,19 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
+            "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.6",
+                "call-bind": "^1.0.5",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.1"
             }
         },
         "wildcard": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "devDependencies": {
         "@tsconfig/node16": "^1.0.2",
         "@types/jest": "^27.5.0",
+        "@types/object.groupby": "^1.0.3",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
         "autoprefixer": "^10.4.7",

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -1,4 +1,4 @@
-import { Annotation } from "../types/Annotation";
+import { Annotation, TextGranularity } from "../types/Annotation";
 import { CancelButton } from "./CancelButton";
 import { DeleteButton } from "./DeleteButton";
 import { SaveButton } from "./SaveButton";
@@ -88,7 +88,7 @@ class AnnotationBlock extends HTMLElement {
             this.labelElement.innerHTML = this.annotation.body[0].label || "";
             this.bodyElement.innerHTML = this.annotation.body[0].value;
         }
-        if (this.annotation.textGranularity !== "line") {
+        if (this.annotation.textGranularity !== TextGranularity.LINE) {
             // line-level annotations do not have labels
             this.append(this.labelElement);
         }

--- a/src/elements/AnnotationBlock.ts
+++ b/src/elements/AnnotationBlock.ts
@@ -88,7 +88,10 @@ class AnnotationBlock extends HTMLElement {
             this.labelElement.innerHTML = this.annotation.body[0].label || "";
             this.bodyElement.innerHTML = this.annotation.body[0].value;
         }
-        this.append(this.labelElement);
+        if (this.annotation.textGranularity !== "line") {
+            // line-level annotations do not have labels
+            this.append(this.labelElement);
+        }
         this.append(this.bodyElement);
 
         if (this.annotation.id) {

--- a/src/elements/AnnotationLabel.ts
+++ b/src/elements/AnnotationLabel.ts
@@ -5,8 +5,10 @@ import { SaveButton } from "./SaveButton";
 import "../styles/AnnotationBlock.scss";
 
 /**
- * HTML div element associated with an annotation, which can be made editable to udpate
- * its associated annotation.
+ * HTML div element associated with a block-level annotation grouping a list of line-level
+ * annotations. Can be made editable to udpate its associated annotation's label ONLY.
+ * Block-level annotations that group line-level annotations do not have editable content
+ * themselves, only editable labels.
  */
 class AnnotationLabel extends HTMLElement {
     annotation: Annotation;
@@ -24,11 +26,11 @@ class AnnotationLabel extends HTMLElement {
     onSave: (label: AnnotationLabel) => Promise<void>;
 
     /**
-     * Instantiate an annotation block.
+     * Instantiate an annotation label.
      *
-     * @param {object} props Properties passed to this annotation block.
-     * @param {Annotation} props.annotation Annotation to associate with this annotation block.
-     * @param {boolean} props.editable True if this annotation block should be editable,
+     * @param {object} props Properties passed to this annotation label.
+     * @param {Annotation} props.annotation Annotation to associate with this annotation label.
+     * @param {boolean} props.editable True if this annotation label should be editable,
      * otherwise false.
      * @param {Function} props.onCancel Cancel annotation handler function.
      * @param {Function} props.onClick Click handler function.
@@ -79,7 +81,7 @@ class AnnotationLabel extends HTMLElement {
                 return;
             }
 
-            // if you click on this block, and it is in read-only mode, make editable
+            // if you click on this label, and it is in read-only mode, make editable
             if (!this.classList.contains("tahqiq-block-editor")) {
                 this.onClick(this);
                 // selection event not fired in this case, so make editable
@@ -94,7 +96,7 @@ class AnnotationLabel extends HTMLElement {
     }
 
     /**
-     * Makes an existing annotation block editable by adding TinyMCE
+     * Makes an existing annotation label editable by adding TinyMCE
      * and adding Save, Cancel, and Delete buttons.
      */
     makeEditable(): void {
@@ -112,9 +114,9 @@ class AnnotationLabel extends HTMLElement {
     }
 
     /**
-     * Converts an annotation block that has been made editable back to display format.
+     * Converts an annotation label that has been made editable back to display format.
      *
-     * @param {boolean} updateAnnotation True if this annotation block's annotation should be
+     * @param {boolean} updateAnnotation True if this annotation label's annotation should be
      * updated in Annotorious, otherwise false.
      */
     makeReadOnly(updateAnnotation?: boolean): void {
@@ -141,7 +143,7 @@ class AnnotationLabel extends HTMLElement {
     }
 
     /**
-     * Update the annotation on this annotation block.
+     * Update the annotation on this annotation label.
      *
      * @param {Annotation} annotation Updated annotation.
      */
@@ -150,7 +152,7 @@ class AnnotationLabel extends HTMLElement {
     }
 
     /**
-     * Set the TinyMCE editor id on this annotation block.
+     * Set the TinyMCE editor id on this annotation label.
      *
      * @param {any} editor The TinyMCE editor instance
      */
@@ -160,11 +162,11 @@ class AnnotationLabel extends HTMLElement {
     }
 
     /**
-     * Set whether or not this annotation block can be clicked
-     * to select. Should not be clickable when another block is
+     * Set whether or not this annotation label can be clicked
+     * to select. Should not be clickable when another block or label is
      * being edited.
      *
-     * @param {boolean} clickable Boolean indicating if this block is clickable
+     * @param {boolean} clickable Boolean indicating if this label is clickable
      */
     setClickable(clickable: boolean): void {
         this.clickable = clickable;

--- a/src/elements/AnnotationLabel.ts
+++ b/src/elements/AnnotationLabel.ts
@@ -1,0 +1,174 @@
+import { Annotation } from "../types/Annotation";
+import { CancelButton } from "./CancelButton";
+import { SaveButton } from "./SaveButton";
+
+import "../styles/AnnotationBlock.scss";
+
+/**
+ * HTML div element associated with an annotation, which can be made editable to udpate
+ * its associated annotation.
+ */
+class AnnotationLabel extends HTMLElement {
+    annotation: Annotation;
+
+    editorId?: string;
+
+    labelElement: HTMLHeadingElement;
+
+    clickable: boolean;
+
+    onCancel: () => void;
+
+    onClick: (label: AnnotationLabel) => void;
+
+    onSave: (label: AnnotationLabel) => Promise<void>;
+
+    /**
+     * Instantiate an annotation block.
+     *
+     * @param {object} props Properties passed to this annotation block.
+     * @param {Annotation} props.annotation Annotation to associate with this annotation block.
+     * @param {boolean} props.editable True if this annotation block should be editable,
+     * otherwise false.
+     * @param {Function} props.onCancel Cancel annotation handler function.
+     * @param {Function} props.onClick Click handler function.
+     * @param {Function} props.onSave Save annotation handler function.
+     * Annotorious display.
+     */
+    constructor(props: {
+        annotation: Annotation;
+        editable: boolean;
+        onCancel: () => void;
+        onClick: (label: AnnotationLabel) => void;
+        onSave: (label: AnnotationLabel) => Promise<void>;
+    }) {
+        super();
+        this.annotation = props.annotation;
+        this.onCancel = props.onCancel;
+        this.onClick = props.onClick;
+        this.onSave = props.onSave;
+
+        // Set class
+        this.setAttribute("class", "tahqiq-block-display");
+
+        // Create and append label element (div with text, contenteditable in edit mode)
+        this.labelElement = document.createElement("h3");
+        this.labelElement.setAttribute("class", "tahqiq-label-display");
+        this.labelElement.setAttribute("data-placeholder", "Optional label");
+        // Create and append body element (div with text in read-only, TinyMCE in edit mode)
+        if (
+            Array.isArray(this.annotation.body) &&
+            this.annotation.body.length > 0 &&
+            this.annotation.body[0].label
+        ) {
+            this.labelElement.innerHTML = this.annotation.body[0].label;
+        } else {
+            this.labelElement.innerHTML = "[no label]";
+        }
+        this.append(this.labelElement);
+
+        if (this.annotation.id) {
+            this.dataset.annotationId = this.annotation.id;
+        }
+
+        // Set click event listener
+        this.clickable = true;
+        this.addEventListener("click", () => {
+            // bail out if clicking disabled
+            if (!this.clickable) {
+                return;
+            }
+
+            // if you click on this block, and it is in read-only mode, make editable
+            if (!this.classList.contains("tahqiq-block-editor")) {
+                this.onClick(this);
+                // selection event not fired in this case, so make editable
+                this.makeEditable();
+            }
+        });
+
+        // Set editable if needed
+        if (props.editable) {
+            this.makeEditable();
+        }
+    }
+
+    /**
+     * Makes an existing annotation block editable by adding TinyMCE
+     * and adding Save, Cancel, and Delete buttons.
+     */
+    makeEditable(): void {
+        if (this.classList.contains("tahqiq-block-editor")) {
+            return;
+        }
+        this.setAttribute("class", "tahqiq-block-editor");
+        // make label editable
+        this.labelElement.setAttribute("contenteditable", "true");
+        this.labelElement.setAttribute("class", "tahqiq-label-editor");
+
+        // add save and cancel buttons
+        this.append(new SaveButton(this));
+        this.append(new CancelButton(this));
+    }
+
+    /**
+     * Converts an annotation block that has been made editable back to display format.
+     *
+     * @param {boolean} updateAnnotation True if this annotation block's annotation should be
+     * updated in Annotorious, otherwise false.
+     */
+    makeReadOnly(updateAnnotation?: boolean): void {
+        this.setAttribute("class", "tahqiq-block-display");
+        this.labelElement.setAttribute("contenteditable", "false");
+        this.labelElement.setAttribute(
+            "class",
+            "tahqiq-line-group-label tahqiq-label-display",
+        );
+        // restore the original content
+        if (updateAnnotation) {
+            if (
+                Array.isArray(this.annotation.body) &&
+                this.annotation.body.length > 0 &&
+                this.annotation.body[0].label
+            ) {
+                this.labelElement.innerHTML = this.annotation.body[0].label;
+            } else {
+                this.labelElement.innerHTML = "[no label]";
+            }
+        }
+        // remove buttons
+        this.querySelectorAll("button").forEach((el) => el.remove());
+    }
+
+    /**
+     * Update the annotation on this annotation block.
+     *
+     * @param {Annotation} annotation Updated annotation.
+     */
+    setAnnotation(annotation: Annotation) {
+        this.annotation = annotation;
+    }
+
+    /**
+     * Set the TinyMCE editor id on this annotation block.
+     *
+     * @param {any} editor The TinyMCE editor instance
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setEditorId(editor: any) {
+        this.editorId = editor.id;
+    }
+
+    /**
+     * Set whether or not this annotation block can be clicked
+     * to select. Should not be clickable when another block is
+     * being edited.
+     *
+     * @param {boolean} clickable Boolean indicating if this block is clickable
+     */
+    setClickable(clickable: boolean): void {
+        this.clickable = clickable;
+    }
+}
+
+export { AnnotationLabel };

--- a/src/elements/CancelButton.ts
+++ b/src/elements/CancelButton.ts
@@ -1,21 +1,23 @@
 import { AnnotationBlock } from "./AnnotationBlock";
+import { AnnotationLabel } from "./AnnotationLabel";
 import "@ungap/custom-elements";
 
 /**
  * A button that cancels editing or creating an annotation on click.
  */
 class CancelButton extends HTMLButtonElement {
-    annotationBlock: AnnotationBlock;
+    annotationElement: AnnotationBlock | AnnotationLabel;
 
     /**
      * Creates a cancel button.
      *
-     * @param {AnnotationBlock} annotationBlock Annotation block associated with this cancel button.
+     * @param {AnnotationBlock | AnnotationLabel} annotationElement Annotation element associated
+     * with this cancel button.
      */
-    constructor(annotationBlock: AnnotationBlock) {
+    constructor(annotationElement: AnnotationBlock | AnnotationLabel) {
         super();
 
-        this.annotationBlock = annotationBlock;
+        this.annotationElement = annotationElement;
 
         // Set class and content
         this.classList.add("tahqiq-button", "tahqiq-cancel-button");
@@ -42,7 +44,7 @@ class CancelButton extends HTMLButtonElement {
         // if a cancel is triggered but there are changes
         // in the editor, give the user a chance to keep editing.
         // NOTE: does not account for changes to label or annotation zone.
-        if (window.tinymce.activeEditor.isDirty()) {
+        if (window.tinymce?.activeEditor?.isDirty()) {
             if (
                 confirm(
                     "You have unsaved changes. Do you want to keep editing?",
@@ -56,8 +58,8 @@ class CancelButton extends HTMLButtonElement {
         // continue on to process the cancel
 
         // if this was cancelled by annotorious, should dispatch CustomEvent with a Selection in the
-        // CustomEvent.details targeting the same canvas as this.annotationBlock.annotation
-        let thisSource = this.annotationBlock.annotation.target.source;
+        // CustomEvent.details targeting the same canvas as this.annotationElement.annotation
+        let thisSource = this.annotationElement.annotation.target.source;
         if (typeof thisSource !== "string") thisSource = thisSource.id;
         const cancelledByAnnotorious =
             evt instanceof CustomEvent &&
@@ -69,13 +71,13 @@ class CancelButton extends HTMLButtonElement {
         // if this was a click event or it was cancelled by annotorious, cancel!
         if (!(evt instanceof CustomEvent) || cancelledByAnnotorious) {
             // clear the selection from the image
-            this.annotationBlock.onCancel();
-            if (this.annotationBlock.annotation.id) {
+            this.annotationElement.onCancel();
+            if (this.annotationElement.annotation.id) {
                 // if annotation was saved previously, restore and make read only
-                this.annotationBlock.makeReadOnly(true);
+                this.annotationElement.makeReadOnly(true);
             } else {
                 // if this was a new annotation, remove the displayBlock
-                this.annotationBlock.remove();
+                this.annotationElement.remove();
             }
         }
     }

--- a/src/elements/SaveButton.ts
+++ b/src/elements/SaveButton.ts
@@ -1,23 +1,22 @@
 import { AnnotationBlock } from "./AnnotationBlock";
+import { AnnotationLabel } from "./AnnotationLabel";
 import "@ungap/custom-elements";
 
 /**
  * A button to save a selected annotation to the store.
  */
 class SaveButton extends HTMLButtonElement {
-    annotationBlock: AnnotationBlock;
+    annotationElement: AnnotationBlock | AnnotationLabel;
 
     /**
      * Creates a new save button.
      *
-     * @param {HTMLElement} annotationBlock Annotation block associated with this save button.
+     * @param {HTMLElement} annotationElement Annotation element associated with this save button.
      */
-    constructor(
-        annotationBlock: AnnotationBlock,
-    ) {
+    constructor(annotationElement: AnnotationBlock | AnnotationLabel) {
         super();
 
-        this.annotationBlock = annotationBlock;
+        this.annotationElement = annotationElement;
 
         // Set class and content
         this.classList.add("tahqiq-button", "tahqiq-save-button");
@@ -34,7 +33,10 @@ class SaveButton extends HTMLButtonElement {
      */
     async handleClick(evt: Event): Promise<void> {
         evt.stopPropagation(); // ensure parent onClick event isn't called
-        await this.annotationBlock.onSave(this.annotationBlock);
+        if (this.annotationElement instanceof AnnotationBlock)
+            await this.annotationElement.onSave(this.annotationElement);
+        else if (this.annotationElement instanceof AnnotationLabel)
+            await this.annotationElement.onSave(this.annotationElement);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { AnnotationBlock } from "./elements/AnnotationBlock";
 import { CancelButton } from "./elements/CancelButton";
 import { DeleteButton } from "./elements/DeleteButton";
 import { SaveButton } from "./elements/SaveButton";
-import { Annotation } from "./types/Annotation";
+import { Annotation, TextGranularity } from "./types/Annotation";
 import { Target } from "./types/Target";
 import { Editor } from "@tinymce/tinymce-webcomponent";
 import AnnotationServerStorage from "./storage";
@@ -285,7 +285,7 @@ class TranscriptionEditor {
                         groupBy(
                             currentAnnotations.filter(
                                 (anno: Annotation) =>
-                                    anno.textGranularity === "line",
+                                    anno.textGranularity === TextGranularity.LINE,
                             ),
                             (anno: Annotation) => anno.partOf || "group",
                         ),
@@ -293,7 +293,7 @@ class TranscriptionEditor {
                         // locate the associated block-level annotation by ID
                         const group = currentAnnotations.find(
                             (anno: Annotation) =>
-                                anno.textGranularity === "block" &&
+                                anno.textGranularity === TextGranularity.BLOCK &&
                                 anno.id === blockId,
                         );
                         // create the line group element and append the group label

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,6 +299,8 @@ class TranscriptionEditor {
                         // create the line group element and append the group label
                         const lineGroup = document.createElement("DIV");
                         lineGroup.classList.add("tahqiq-line-group");
+                        // allow editing the label associated with the group of line-level
+                        // annotations, since the group itself is not editable, only the lines
                         this.annotationContainer.append(
                             new AnnotationLabel({
                                 annotation: group,
@@ -310,7 +312,7 @@ class TranscriptionEditor {
                             }),
                             lineGroup,
                         );
-                        // create the editable line blocks
+                        // create the editable line-level content blocks
                         this.createBlocks(lines, lineGroup);
                     });
                 } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import AnnotationServerStorage from "./storage";
 import "@ungap/custom-elements";
 
 import "./styles/index.scss";
+import { AnnotationLabel } from "./elements/AnnotationLabel";
 
 declare global {
     /**
@@ -26,6 +27,15 @@ declare global {
 // define a custom event to indicate that annotations should have positions recalculated
 const ReloadPositionsEvent = new Event("reload-all-positions");
 
+// Shim for Object.groupBy() until it's implemented in all browsers
+// via https://stackoverflow.com/a/62765924/394067
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, jsdoc/require-jsdoc
+const groupBy = <T, K extends keyof any>(arr: T[], key: (i: T) => K) =>
+    arr.reduce((groups, item) => {
+        (groups[key(item)] ||= []).push(item);
+        return groups;
+    }, {} as Record<K, T[]>);
+
 /**
  * Custom annotation editor for Geniza project
  */
@@ -33,7 +43,7 @@ class TranscriptionEditor {
     anno;
 
     annotationContainer: HTMLElement;
-    
+
     toolbarContainer: HTMLFieldSetElement;
 
     storage;
@@ -70,6 +80,8 @@ class TranscriptionEditor {
         this.storage = storage;
         // disable the default annotorious editor (headless mode)
         this.anno.disableEditor = true;
+        // read only in line mode
+        this.anno.readOnly = this.storage.settings.lineMode;
         this.annotationContainer = annotationContainer;
         this.currentAnnotationBlock = null;
 
@@ -91,6 +103,9 @@ class TranscriptionEditor {
             });
         if (!customElements.get("annotation-block"))
             customElements.define("annotation-block", AnnotationBlock);
+
+        if (!customElements.get("annotation-label"))
+            customElements.define("annotation-label", AnnotationLabel);
 
         // attach event listeners
         document.addEventListener(
@@ -124,11 +139,14 @@ class TranscriptionEditor {
             Editor();
         }
         if (!window.tinyConfig) {
+            // hide numberded list in line-level editor mode
+            const toolbar = this.storage.settings?.lineMode
+                ? "language | strikethrough superscript | undo redo | "
+                : "language | numlist | strikethrough superscript | undo redo | ";
             window.tinyConfig = {
-                height: 500,
+                height: this.storage?.settings?.lineMode ? 150 : 500,
                 plugins: "lists",
-                toolbar:
-                    "language | numlist | strikethrough superscript | undo redo | ",
+                toolbar,
                 directionality: textDirection || "rtl",
                 formats: {
                     strikethrough: { inline: "del" },
@@ -207,46 +225,101 @@ class TranscriptionEditor {
     }
 
     /**
+     * Helper method to sort annotations by position and create and append
+     * AnnotationBlocks for each.
+     *
+     * @param {Array<Annotation>} annotations A list of annotations
+     * @param {HTMLElement} container A container in which to place the blocks
+     */
+    createBlocks(annotations: Array<Annotation>, container: HTMLElement) {
+        // sort by position attribute if present
+        annotations.sort((a: Annotation, b: Annotation) => {
+            // null position should go to the end; it means dragged from another canvas
+            if (a["schema:position"] === null) return 1;
+            if (b["schema:position"] === null) return -1;
+            if (a["schema:position"] && b["schema:position"])
+                return a["schema:position"] - b["schema:position"];
+            return 0;
+        });
+        // append annotation blocks to display current annotations
+        annotations.forEach((annotation: Annotation) => {
+            container.append(
+                new AnnotationBlock({
+                    annotation,
+                    editable: false,
+                    onCancel: this.handleCancel.bind(this),
+                    onClick: this.handleClickAnnotationBlock.bind(this),
+                    onDelete: this.handleDeleteAnnotation.bind(this),
+                    onDrag: this.handleDrag.bind(this),
+                    onReorder: this.handleDropAnnotationBlock.bind(this),
+                    onSave: this.handleSaveAnnotation.bind(this),
+                    updateAnnotorious: this.anno.addAnnotation,
+                }),
+            );
+        });
+    }
+
+    /**
      * Handler for custom annotations loaded event triggered by storage plugin.
      *
      * @param {Event} e The annotations-loaded custom event
      */
     async handleAnnotationsLoaded(e: Event) {
         // only reload if the event target (i.e. canvas) matches this one
-        if (e instanceof CustomEvent && e.detail?.target === this.storage?.settings?.target) {
+        if (
+            e instanceof CustomEvent &&
+            e.detail?.target === this.storage?.settings?.target
+        ) {
             // remove any existing annotation blocks and drop zones, in case of update
             this.annotationContainer
-                .querySelectorAll("[class^='tahqiq-block']")
+                .querySelectorAll(
+                    "[class^='tahqiq-block'], .tahqiq-drop-zone, .tahqiq-line-group",
+                )
                 .forEach((el) => el.remove());
-            this.annotationContainer.querySelector(".tahqiq-drop-zone")?.remove();
             // display all current annotations
             const currentAnnotations = e.detail.annotations;
             if (currentAnnotations) {
-                // sort by position attribute if present
-                currentAnnotations.sort((a: Annotation, b: Annotation) => {
-                    // null position should go to the end; it means dragged from another canvas
-                    if (a["schema:position"] === null) return 1;
-                    if (b["schema:position"] === null) return -1;
-                    if (a["schema:position"] && b["schema:position"])
-                        return a["schema:position"] - b["schema:position"];
-                    return 0;
-                });
-                // append annotation blocks to display current annotations
-                currentAnnotations.forEach((annotation: Annotation) => {
-                    this.annotationContainer.append(
-                        new AnnotationBlock({
-                            annotation,
-                            editable: false,
-                            onCancel: this.handleCancel.bind(this),
-                            onClick: this.handleClickAnnotationBlock.bind(this),
-                            onDelete: this.handleDeleteAnnotation.bind(this),
-                            onDrag: this.handleDrag.bind(this),
-                            onReorder: this.handleDropAnnotationBlock.bind(this),
-                            onSave: this.handleSaveAnnotation.bind(this),
-                            updateAnnotorious: this.anno.addAnnotation,
-                        }),
+                if (this.storage.settings.lineMode) {
+                    // line mode: group line-level annotations by associated block-level ID
+                    Object.entries(
+                        groupBy(
+                            currentAnnotations.filter(
+                                (anno: Annotation) =>
+                                    anno.textGranularity === "line",
+                            ),
+                            (anno: Annotation) => anno.partOf || "group",
+                        ),
+                    ).forEach(([blockId, lines]) => {
+                        // locate the associated block-level annotation by ID
+                        const group = currentAnnotations.find(
+                            (anno: Annotation) =>
+                                anno.textGranularity === "block" &&
+                                anno.id === blockId,
+                        );
+                        // create the line group element and append the group label
+                        const lineGroup = document.createElement("DIV");
+                        lineGroup.classList.add("tahqiq-line-group");
+                        this.annotationContainer.append(
+                            new AnnotationLabel({
+                                annotation: group,
+                                editable: false,
+                                onCancel: this.handleCancel.bind(this),
+                                onClick:
+                                    this.handleClickAnnotationBlock.bind(this),
+                                onSave: this.handleSaveAnnotation.bind(this),
+                            }),
+                            lineGroup,
+                        );
+                        // create the editable line blocks
+                        this.createBlocks(lines, lineGroup);
+                    });
+                } else {
+                    // block mode: just create blocks from all annotations
+                    this.createBlocks(
+                        currentAnnotations,
+                        this.annotationContainer,
                     );
-                });
+                }
             }
             // if no annotations returned, append a drop zone here so we can drop annotations
             // from other canvases onto this one
@@ -306,8 +379,10 @@ class TranscriptionEditor {
      * When cancel button is clicked, cancel with annotorious and set all draggable
      */
     handleCancel() {
-        // cancel with annotorious
-        this.anno.cancelSelected();
+        if (this.anno.getSelected()) {
+            // cancel with annotorious
+            this.anno.cancelSelected();
+        }
         // make all annotations draggable
         this.setAllInteractive(true);
         // raise global cancellation event
@@ -397,8 +472,16 @@ class TranscriptionEditor {
                 // reload positions of all annotation blocks except this one
                 const blocks = this.annotationContainer.querySelectorAll(".tahqiq-block-display");
                 const annotations = Array.from(blocks).map((block) => {
-                    if (block instanceof AnnotationBlock 
-                    && block.annotation.id !== annotationBlock.annotation.id)
+                    if (
+                        block instanceof AnnotationBlock &&
+                        block.annotation.id !== annotationBlock.annotation.id &&
+                        // if annotation is line-level and has an associated block, reload only
+                        // the annotations in its block for performance
+                        (
+                            !block.annotation.partOf ||
+                            block.annotation.partOf === annotationBlock.annotation.partOf
+                        )
+                    )
                         return block.annotation;
                 });
                 await this.updateSequence(annotations);
@@ -415,19 +498,22 @@ class TranscriptionEditor {
      * Saves the passed annotation block's associated annotation using its editor
      * content (and label if present), and makes the annotation block read only.
      *
-     * @param {HTMLElement} annotationBlock Annotation block associated with the annotation to save.
+     * @param {AnnotationBlock | AnnotationLabel} annotationElement Annotation element
+     * associated with the annotation to save.
      */
-    async handleSaveAnnotation(annotationBlock: AnnotationBlock) {
+    async handleSaveAnnotation(
+        annotationElement: AnnotationBlock | AnnotationLabel,
+    ) {
         this.storage.alert("Saving...");
-        const annotation = annotationBlock.annotation;
-        const editorContent = window.tinymce.get(annotationBlock.editorId).getContent();
+        const annotation = annotationElement.annotation;
+        const editorContent = window.tinymce?.get(annotationElement.editorId)?.getContent();
         // add the content to the annotation
         if (Array.isArray(annotation.body) && annotation.body.length == 0) {
             annotation.body.push({
                 type: "TextualBody",
                 value: editorContent || "",
                 format: "text/html",
-                label: annotationBlock.labelElement.textContent || undefined,
+                label: annotationElement.labelElement.textContent || undefined,
                 // purpose: "transcribing",
                 // - purpose on body is only needed if more than one body
                 //   (e.g., transcription + tags in the same annotation)
@@ -435,28 +521,34 @@ class TranscriptionEditor {
         } else if (Array.isArray(annotation.body)) {
             // assume text content is first body element
             annotation.body[0].value = editorContent || "";
-            if (annotationBlock.labelElement.textContent) {
-                annotation.body[0].label = annotationBlock.labelElement.textContent;
-            }
+            annotation.body[0].label = annotationElement.labelElement.textContent || undefined;
         }
         // turn off draggability for all blocks while saving
         this.setAllInteractive(false);
-        // update with annotorious, save to, and reload from storage backend
-        await this.anno.updateSelected(annotation, true);
+        if (annotationElement instanceof AnnotationBlock) {
+            // update with annotorious, save to, and reload from storage backend
+            await this.anno.updateSelected(annotation, true);
+        } else {
+            await this.storage.handleUpdateAnnotationInStore(annotation);
+        }
     }
 
     /**
      * On clicking an AnnotationBlock, selects the associated annotation in Annotorious
      * and makes all other AnnotationBlocks read-only.
      *
-     * @param {Annotation} annotationBlock The AnnotationBlock that was clicked.
+     * @param {AnnotationBlock | AnnotationLabel} annotationElement The element that was clicked.
      */
-    handleClickAnnotationBlock(annotationBlock: AnnotationBlock) {
-        if (annotationBlock.annotation.id) {
-            // highlight the zone
-            this.anno.selectAnnotation(annotationBlock.annotation.id);
+    handleClickAnnotationBlock(
+        annotationElement: AnnotationBlock | AnnotationLabel,
+    ) {
+        if (annotationElement.annotation.id) {
+            if (annotationElement instanceof AnnotationBlock) {
+                // highlight the zone (block only)
+                this.anno.selectAnnotation(annotationElement.annotation.id);
+            }
             // make sure no other annotation blocks are editable
-            this.makeAllReadOnlyExcept(annotationBlock);
+            this.makeAllReadOnlyExcept(annotationElement);
             // ensure no annotation block is draggable
             this.setAllInteractive(false);
         }
@@ -485,7 +577,7 @@ class TranscriptionEditor {
      *
      * TODO: Test once DragEvent is implemented in jsdom
      * https://github.com/jsdom/jsdom/blob/28ed5/test/web-platform-tests/to-run.yaml#L648-L654
-     * 
+     *
      * @param {DragEvent} evt The "drop" event that triggered this handler
      */
     async handleDropAnnotationBlock(evt: DragEvent) {
@@ -609,15 +701,18 @@ class TranscriptionEditor {
     /**
      * Sets all annotation blocks to read-only, except the passed one.
      *
-     * @param {AnnotationBlock} annotationBlock The annotation block not to make read-only.
+     * @param {AnnotationBlock | AnnotationLabel} annotationElement The annotation block not
+     * to make read-only.
      */
-    makeAllReadOnlyExcept(annotationBlock: AnnotationBlock) {
+    makeAllReadOnlyExcept(
+        annotationElement: AnnotationBlock | AnnotationLabel,
+    ) {
         this.annotationContainer
-            .querySelectorAll(".tahqiq-block-editor")
+            .querySelectorAll(".tahqiq-block-editor, .tahqiq-label-editor")
             .forEach((block) => {
                 if (
-                    block instanceof AnnotationBlock &&
-                    block !== annotationBlock
+                    (block instanceof AnnotationBlock || block instanceof AnnotationLabel) &&
+                    block !== annotationElement
                 ) {
                     block.makeReadOnly();
                 }
@@ -628,7 +723,7 @@ class TranscriptionEditor {
      * Enable or disable all pointer events on the annotorious canvas in the current instance.
      * If an annotorious rectangle is currently selected and editable, it will remain movable
      * and resizable (pointer-events: all), even if enabled is set false.
-     * 
+     *
      * @param {boolean} enabled Whether or not pointer events should be enabled
      */
     setAnnotoriousPointerEvents(enabled: boolean) {
@@ -689,15 +784,19 @@ class TranscriptionEditor {
     /**
      * Set draggability on or off for all blocks; set pointer-events enabled or disabled on
      * the Annotorious canvas.
-     * 
+     *
      * @param {boolean} interactive Whether or not blocks should be draggable and clickable
      */
     setAllInteractive(interactive: boolean) {
         this.annotationContainer
-            .querySelectorAll("annotation-block")
+            .querySelectorAll("annotation-block, annotation-label")
             .forEach((block) => {
                 if (block instanceof AnnotationBlock) {
-                    block.setDraggable(interactive);
+                    // no dragging in line mode
+                    block.setDraggable(interactive && !this.storage?.settings?.lineMode);
+                    block.setClickable(interactive);
+                } else if (block instanceof AnnotationLabel) {
+                    // no dragging annotationlabel (only shows up in line mode)
                     block.setClickable(interactive);
                 }
             });

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,4 @@
-import type { Annotation, SavedAnnotation } from "./types/Annotation";
+import { TextGranularity, type Annotation, type SavedAnnotation } from "./types/Annotation";
 import type { Source } from "./types/Source";
 import type { Settings } from "./types/Settings";
 
@@ -58,7 +58,7 @@ class AnnotationServerStorage {
             if (this.settings.lineMode) {
                 // in line-by-line editing mode, only render line-level annotations in annotorious
                 await this.anno.setAnnotations(
-                    annotations?.filter((a) => a.textGranularity === "line"),
+                    annotations?.filter((a) => a.textGranularity === TextGranularity.LINE),
                 );
             } else {
                 // otherwise render block-level annotations

--- a/src/styles/AnnotationBlock.scss
+++ b/src/styles/AnnotationBlock.scss
@@ -38,10 +38,49 @@
         background-color: white;
         color: black;
         min-height: 3em;
-        border: 1px solid #ccc;;
-        &[contenteditable=true]:empty:not(:focus):before {
+        border: 1px solid #ccc;
+        &[contenteditable="true"]:empty:not(:focus):before {
             content: attr(data-placeholder);
             color: gray;
         }
     }
+}
+
+// Line group styling for line-level annotation editing
+.tahqiq-line-group {
+    border: 1px solid rgba(128, 128, 128, 0.5);
+    margin: 0 0 1rem;
+    counter-reset: linecounter;
+    // styling for a line in a group
+    .tahqiq-block-display {
+        border: none;
+        padding: 0;
+        margin: 0;
+
+        counter-increment: linecounter;
+        display: flex;
+        align-items: center;
+        &:hover {
+            background-color: rgba(69, 175, 214, 0.5);
+            cursor: pointer;
+        }
+        &::before {
+            content: counter(linecounter);
+            flex-basis: 2rem;
+        }
+    }
+    .tahqiq-block-editor {
+        // editor should also increment the line count
+        counter-increment: linecounter;
+    }
+    // Prevent cursor/hover effects on other lines when an editor is open
+    &:has(.tahqiq-block-editor) .tahqiq-block-display:hover {
+        background-color: transparent;
+        cursor: default;
+    }
+}
+
+// Remove margins on labels in line-level editor mode
+annotation-label.tahqiq-block-display {
+    margin: 0;
 }

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -2,6 +2,14 @@ import type { Body } from "./Body";
 import type { Target } from "./Target";
 
 /**
+ * Constants for text granularity.
+ */
+enum TextGranularity {
+    LINE = "line",
+    BLOCK = "block",
+}
+
+/**
  * W3C Annotation (does not meet the full specification) of the type used by Annotorious.
  * https://www.w3.org/TR/annotation-model/#annotations
  */
@@ -14,7 +22,7 @@ interface Annotation {
     partOf?: string;
     "schema:position"?: number | null;
     target: Target;
-    textGranularity?: string;
+    textGranularity?: TextGranularity;
     type: string;
 }
 
@@ -25,4 +33,4 @@ interface SavedAnnotation extends Annotation {
     id: string;
 }
 
-export { Annotation, SavedAnnotation };
+export { Annotation, SavedAnnotation, TextGranularity };

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -11,8 +11,10 @@ interface Annotation {
     "dc:source"?: string;
     id?: string;
     motivation?: string | string[];
+    partOf?: string;
     "schema:position"?: number | null;
     target: Target;
+    textGranularity?: string;
     type: string;
 }
 

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -8,6 +8,7 @@ interface Settings {
     csrf_token: string;
     secondaryMotivation?: string;
     sourceUri?: string;
+    lineMode?: boolean;
 }
 
 export { Settings };


### PR DESCRIPTION
see also https://github.com/Princeton-CDH/geniza/pull/1537

## In this PR
- Support for line and block level annotation editing in new "line mode"

## Notes
- The biggest change here is actually a new custom element that's _just_ for editing an annotation label. That's because block-level annotations must not be otherwise editable in line mode. (Conversely, individual line-level annotations have no labels themselves and thus the label editor is disabled for them.) 
  - It ends up having many methods of `AnnotationBlock` written in a similar, but not identical, way—unfortunately I ultimately couldn't easily leverage polymorphism.
- In line mode, I disabled most functionality except for editing text contents of line-level annotations, and label content of block-level annotations—mostly to avoid dealing with complications and bugs that arise from the rest of the functionality. I figure we can add them back in one by one if/when needed in later passes.
- There were some strange interactions between blocks and lines contained within, namely that the two were constantly z-fighting and it seemed random which would be selected when you clicked. So I decided just to not display the block-level annotations in Annotorious when in line mode, though their geometry is being stored.
- Note that the cropped line image by each line of text from your original proof of concept is not included at this point.
- Thoughts on whether this needs unit testing? My inclination is not to write them, since this may be somewhat provisional.