### PR TITLE
Add If-Match headers on delete/update; alert user on 412 error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -462,15 +462,15 @@ class TranscriptionEditor {
                     "error",
                 );
             } else {
+                // calling removeAnnotation doesn't fire the deleteAnnotation event,
+                // so we have to trigger the deletion explicitly (also avoids race condition!)
+                await this.storage.delete(annotationBlock.annotation);
                 // remove the highlight zone from the image
                 this.anno.removeAnnotation(annotationBlock.annotation.id);
                 // decrement annotation count
                 this.storage.setAnnotationCount(this.storage.annotationCount - 1);
                 // remove the edit/display displayBlock
                 annotationBlock.remove();
-                // calling removeAnnotation doesn't fire the deleteAnnotation event,
-                // so we have to trigger the deletion explicitly (also avoids race condition!)
-                await this.storage.delete(annotationBlock.annotation);
                 // reload positions of all annotation blocks except this one
                 const blocks = this.annotationContainer.querySelectorAll(".tahqiq-block-display");
                 const annotations = Array.from(blocks).map((block) => {

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -27,10 +27,11 @@ interface Annotation {
 }
 
 /**
- * Saved W3C Annotation, which will have received an ID from the annotation store.
+ * Saved W3C Annotation, which will have received an ID and etag from the annotation store.
  */
 interface SavedAnnotation extends Annotation {
     id: string;
+    etag: string;
 }
 
 export { Annotation, SavedAnnotation, TextGranularity };


### PR DESCRIPTION
## In this PR

Per https://github.com/Princeton-CDH/geniza/issues/965:
- add If-Match headers to delete/update API calls (pgp will handle)
- add special alerts for 412 errors with clear instructions
- reselect annotations if an error is encountered after it is deselected
- include some reordering of calls to prevent undesired behavior from occurring when an error is encountered