### PR TITLE
Use <i> for italics (language change) instead of <em>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.5.1
+
+### Bug fixes
+
+- Use `i` element instead of `em` for semantic accuracy and to prevent conflicts with other uses of `em`
+
 ## 1.5.0
 
 ### Breaking changes

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,11 +153,12 @@ class TranscriptionEditor {
                 toolbar,
                 directionality: textDirection || "rtl",
                 formats: {
-                    italic: { inline: "em" },
+                    italic: { inline: "i" },
                     strikethrough: { inline: "del" },
                     // A custom format for insertion element
                     ins: { inline: "ins" },
                 },
+                extended_valid_elements: "i,em",
                 content_langs: [
                     { title: "English", code: "en" },
                     { title: "Hebrew", code: "he" },


### PR DESCRIPTION
## In this PR

- Use `<i>` instead of `<em>` as italics here are being used to indicate language change, not emphasis
- In addition, and more importantly for geniza, `<em>` is used by solr to highlight matches, which would conflict with its usage for italics